### PR TITLE
docs: add PT1 documentation structure

### DIFF
--- a/docs/pt1/001-engineering-report/engineering-report.md
+++ b/docs/pt1/001-engineering-report/engineering-report.md
@@ -1,0 +1,35 @@
+# Caribou PT1 Engineering Report
+
+**Status:** In progress  
+**Phase:** PT1 — Proof of Concept  
+**Goal:** Validate structural integrity and power architecture. Milestone: stable tethered hover flight.
+
+---
+
+## 1. Overview
+
+_Placeholder — describe the PT1 build scope and objectives._
+
+## 2. Frame
+
+_Placeholder — materials, dimensions, FEA results, build notes._
+
+## 3. Propulsion
+
+_Placeholder — motor selection, ESC, prop sizing, thrust measurements._
+
+## 4. Power Architecture
+
+_Placeholder — battery configuration, voltage, current limits, HV safety._
+
+## 5. Avionics
+
+_Placeholder — flight controller, GPS, telemetry, wiring._
+
+## 6. Test Results
+
+_Placeholder — tethered hover data, issues found, lessons learned._
+
+## 7. Next Steps
+
+_Placeholder — recommendations for PT2._

--- a/docs/pt1/002-manufacturing-guides/frame-assembly.md
+++ b/docs/pt1/002-manufacturing-guides/frame-assembly.md
@@ -1,0 +1,26 @@
+# Frame Assembly Guide — PT1
+
+**Status:** In progress  
+**Applies to:** PT1 test frame
+
+---
+
+## 1. Overview
+
+_Placeholder — describe the frame design, materials, and assembly approach._
+
+## 2. Parts List
+
+_Placeholder — BOM for the PT1 frame._
+
+## 3. Tools Required
+
+_Placeholder — list of tools and equipment needed._
+
+## 4. Assembly Steps
+
+_Placeholder — step-by-step frame build instructions._
+
+## 5. Quality Checks
+
+_Placeholder — inspection points, torque specs, alignment checks._

--- a/docs/pt1/002-manufacturing-guides/structural-assembly.md
+++ b/docs/pt1/002-manufacturing-guides/structural-assembly.md
@@ -1,4 +1,4 @@
-# Frame Assembly Guide — PT1
+# Structural Assembly Guide — PT1
 
 **Status:** In progress  
 **Applies to:** PT1 test frame

--- a/docs/pt1/003-user-guides/maintenance-guide.md
+++ b/docs/pt1/003-user-guides/maintenance-guide.md
@@ -1,0 +1,30 @@
+# Maintenance Guide — PT1
+
+**Status:** In progress  
+**Applies to:** PT1 test frame
+
+---
+
+## 1. Overview
+
+_Placeholder — describe the maintenance philosophy and intervals._
+
+## 2. Pre-Flight Checks
+
+_Placeholder — checklist before each flight._
+
+## 3. Post-Flight Checks
+
+_Placeholder — checklist after each flight._
+
+## 4. Periodic Maintenance
+
+_Placeholder — scheduled inspections, lubrication, fastener checks._
+
+## 5. Common Issues and Fixes
+
+_Placeholder — troubleshooting guide for known failure modes._
+
+## 6. Storage
+
+_Placeholder — battery storage, environmental requirements, long-term storage procedure._


### PR DESCRIPTION
Creates the initial documentation layout under `docs/pt1/`:

```
docs/pt1/
├── 001-engineering-report/
│   └── engineering-report.md
├── 002-manufacturing-guides/
│   └── frame-assembly.md
└── 003-user-guides/
    └── maintenance-guide.md
```

All files are placeholder/stub content, ready to be filled in as PT1 progresses.

cc @far1no