### PR TITLE
Fix CBC schematic library references

### DIFF
--- a/engineering/electronics/pcbs/CBC_PCB/kicad/CAN SECTION.kicad_sch
+++ b/engineering/electronics/pcbs/CBC_PCB/kicad/CAN SECTION.kicad_sch
@@ -6789,7 +6789,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:GRM1555C1H221JA01D")
+		(lib_id "EasyEDA_Lib:GRM1555C1H221JA01D")
 		(at 323.85 196.85 90)
 		(unit 1)
 		(body_style 1)
@@ -6924,7 +6924,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:ADM3053BRWZ-REEL7")
+		(lib_id "EasyEDA_Lib:ADM3053BRWZ-REEL7")
 		(at 220.98 55.88 0)
 		(unit 1)
 		(body_style 1)
@@ -7424,7 +7424,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:CL21A475KBQNNNE")
+		(lib_id "EasyEDA_Lib:CL21A475KBQNNNE")
 		(at 196.85 201.93 90)
 		(unit 1)
 		(body_style 1)
@@ -7558,7 +7558,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:GRM1555C1H221JA01D")
+		(lib_id "EasyEDA_Lib:GRM1555C1H221JA01D")
 		(at 314.96 59.69 90)
 		(unit 1)
 		(body_style 1)
@@ -7693,7 +7693,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:H1OEL89CSC-SUGYLC-8M")
+		(lib_id "EasyEDA_Lib:H1OEL89CSC-SUGYLC-8M")
 		(at 41.91 215.9 0)
 		(unit 1)
 		(body_style 1)
@@ -7904,7 +7904,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:0603WAF1200T5E")
+		(lib_id "EasyEDA_Lib:0603WAF1200T5E")
 		(at 302.26 49.53 90)
 		(unit 1)
 		(body_style 1)
@@ -8038,7 +8038,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:RC0402FR-070RL")
+		(lib_id "EasyEDA_Lib:RC0402FR-070RL")
 		(at 248.92 36.83 0)
 		(unit 1)
 		(body_style 1)
@@ -8407,7 +8407,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:GRM21BR61H106KE43L")
+		(lib_id "EasyEDA_Lib:GRM21BR61H106KE43L")
 		(at 207.01 203.2 90)
 		(unit 1)
 		(body_style 1)
@@ -8619,7 +8619,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:H1OEL89CSC-SUGYLC-8M")
+		(lib_id "EasyEDA_Lib:H1OEL89CSC-SUGYLC-8M")
 		(at 44.45 74.93 0)
 		(unit 1)
 		(body_style 1)
@@ -8831,7 +8831,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:RC0402FR-070RL")
+		(lib_id "EasyEDA_Lib:RC0402FR-070RL")
 		(at 265.43 172.72 0)
 		(unit 1)
 		(body_style 1)
@@ -9200,7 +9200,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:NUP2105LT1G")
+		(lib_id "EasyEDA_Lib:NUP2105LT1G")
 		(at 335.28 214.63 180)
 		(unit 1)
 		(body_style 1)
@@ -9416,7 +9416,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:CL21A475KBQNNNE")
+		(lib_id "EasyEDA_Lib:CL21A475KBQNNNE")
 		(at 175.26 49.53 90)
 		(unit 1)
 		(body_style 1)
@@ -9627,7 +9627,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:ACT45B-510-2P-TF")
+		(lib_id "EasyEDA_Lib:ACT45B-510-2P-TF")
 		(at 289.56 54.61 0)
 		(unit 1)
 		(body_style 1)
@@ -9768,7 +9768,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:CL21A475KBQNNNE")
+		(lib_id "EasyEDA_Lib:CL21A475KBQNNNE")
 		(at 180.34 66.04 90)
 		(unit 1)
 		(body_style 1)
@@ -9979,7 +9979,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:CL21A475KBQNNNE")
+		(lib_id "EasyEDA_Lib:CL21A475KBQNNNE")
 		(at 191.77 185.42 90)
 		(unit 1)
 		(body_style 1)
@@ -10347,7 +10347,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:GRM21BR61H106KE43L")
+		(lib_id "EasyEDA_Lib:GRM21BR61H106KE43L")
 		(at 278.13 207.01 90)
 		(unit 1)
 		(body_style 1)
@@ -10715,7 +10715,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:NUP2105LT1G")
+		(lib_id "EasyEDA_Lib:NUP2105LT1G")
 		(at 326.39 77.47 180)
 		(unit 1)
 		(body_style 1)
@@ -10854,7 +10854,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:0603WAF1200T5E")
+		(lib_id "EasyEDA_Lib:0603WAF1200T5E")
 		(at 311.15 186.69 90)
 		(unit 1)
 		(body_style 1)
@@ -11065,7 +11065,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:PZ254V-11-02P")
+		(lib_id "EasyEDA_Lib:PZ254V-11-02P")
 		(at 316.23 194.31 0)
 		(unit 1)
 		(body_style 1)
@@ -11279,7 +11279,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:PZ254V-11-02P")
+		(lib_id "EasyEDA_Lib:PZ254V-11-02P")
 		(at 307.34 57.15 0)
 		(unit 1)
 		(body_style 1)
@@ -11571,7 +11571,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:GRM21BR61H106KE43L")
+		(lib_id "EasyEDA_Lib:GRM21BR61H106KE43L")
 		(at 185.42 50.8 90)
 		(unit 1)
 		(body_style 1)
@@ -12330,7 +12330,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:GRM1555C1H221JA01D")
+		(lib_id "EasyEDA_Lib:GRM1555C1H221JA01D")
 		(at 323.85 185.42 90)
 		(unit 1)
 		(body_style 1)
@@ -12620,7 +12620,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:GRM21BR61H106KE43L")
+		(lib_id "EasyEDA_Lib:GRM21BR61H106KE43L")
 		(at 190.5 67.31 90)
 		(unit 1)
 		(body_style 1)
@@ -12831,7 +12831,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:GRM21BR61H106KE43L")
+		(lib_id "EasyEDA_Lib:GRM21BR61H106KE43L")
 		(at 100.33 92.71 90)
 		(unit 1)
 		(body_style 1)
@@ -13275,7 +13275,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:CC0402KRX7R7BB104")
+		(lib_id "EasyEDA_Lib:CC0402KRX7R7BB104")
 		(at 107.95 92.71 90)
 		(unit 1)
 		(body_style 1)
@@ -13647,7 +13647,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:CC0402JRNPO9BN220")
+		(lib_id "EasyEDA_Lib:CC0402JRNPO9BN220")
 		(at 54.61 219.71 90)
 		(unit 1)
 		(body_style 1)
@@ -13860,7 +13860,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:CC0402JRNPO9BN220")
+		(lib_id "EasyEDA_Lib:CC0402JRNPO9BN220")
 		(at 57.15 78.74 90)
 		(unit 1)
 		(body_style 1)
@@ -13994,7 +13994,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:CL21A475KBQNNNE")
+		(lib_id "EasyEDA_Lib:CL21A475KBQNNNE")
 		(at 87.63 232.41 90)
 		(unit 1)
 		(body_style 1)
@@ -14205,7 +14205,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:CL21A475KBQNNNE")
+		(lib_id "EasyEDA_Lib:CL21A475KBQNNNE")
 		(at 90.17 91.44 90)
 		(unit 1)
 		(body_style 1)
@@ -14339,7 +14339,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:GRM1555C1H221JA01D")
+		(lib_id "EasyEDA_Lib:GRM1555C1H221JA01D")
 		(at 314.96 48.26 90)
 		(unit 1)
 		(body_style 1)
@@ -14474,7 +14474,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:MCP2515T-I/ST")
+		(lib_id "EasyEDA_Lib:MCP2515T-I/ST")
 		(at 100.33 54.61 0)
 		(unit 1)
 		(body_style 1)
@@ -14663,7 +14663,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:MCP2515T-I/ST")
+		(lib_id "EasyEDA_Lib:MCP2515T-I/ST")
 		(at 97.79 195.58 0)
 		(unit 1)
 		(body_style 1)
@@ -14929,7 +14929,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:GRM21BR61H106KE43L")
+		(lib_id "EasyEDA_Lib:GRM21BR61H106KE43L")
 		(at 261.62 71.12 90)
 		(unit 1)
 		(body_style 1)
@@ -15063,7 +15063,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:RT0402BRD0710KL")
+		(lib_id "EasyEDA_Lib:RT0402BRD0710KL")
 		(at 69.85 27.94 90)
 		(unit 1)
 		(body_style 1)
@@ -15429,7 +15429,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:CC0402KRX7R7BB104")
+		(lib_id "EasyEDA_Lib:CC0402KRX7R7BB104")
 		(at 105.41 233.68 90)
 		(unit 1)
 		(body_style 1)
@@ -15721,7 +15721,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:CC0402KRX7R7BB104")
+		(lib_id "EasyEDA_Lib:CC0402KRX7R7BB104")
 		(at 284.48 207.01 90)
 		(unit 1)
 		(body_style 1)
@@ -15935,7 +15935,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:RT0402BRD0710KL")
+		(lib_id "EasyEDA_Lib:RT0402BRD0710KL")
 		(at 67.31 168.91 90)
 		(unit 1)
 		(body_style 1)
@@ -16069,7 +16069,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:CC0402JRNPO9BN220")
+		(lib_id "EasyEDA_Lib:CC0402JRNPO9BN220")
 		(at 30.48 78.74 90)
 		(unit 1)
 		(body_style 1)
@@ -16280,7 +16280,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:GRM21BR61H106KE43L")
+		(lib_id "EasyEDA_Lib:GRM21BR61H106KE43L")
 		(at 201.93 186.69 90)
 		(unit 1)
 		(body_style 1)
@@ -16568,7 +16568,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:GRM21BR61H106KE43L")
+		(lib_id "EasyEDA_Lib:GRM21BR61H106KE43L")
 		(at 97.79 233.68 90)
 		(unit 1)
 		(body_style 1)
@@ -16781,7 +16781,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:ADM3053BRWZ-REEL7")
+		(lib_id "EasyEDA_Lib:ADM3053BRWZ-REEL7")
 		(at 237.49 191.77 0)
 		(unit 1)
 		(body_style 1)
@@ -17047,7 +17047,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:CC0402KRX7R7BB104")
+		(lib_id "EasyEDA_Lib:CC0402KRX7R7BB104")
 		(at 267.97 71.12 90)
 		(unit 1)
 		(body_style 1)
@@ -17340,7 +17340,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:CC0402JRNPO9BN220")
+		(lib_id "EasyEDA_Lib:CC0402JRNPO9BN220")
 		(at 27.94 219.71 90)
 		(unit 1)
 		(body_style 1)
@@ -17551,7 +17551,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:ACT45B-510-2P-TF")
+		(lib_id "EasyEDA_Lib:ACT45B-510-2P-TF")
 		(at 298.45 191.77 0)
 		(unit 1)
 		(body_style 1)

--- a/engineering/electronics/pcbs/CBC_PCB/kicad/ESP32 SECTION.kicad_sch
+++ b/engineering/electronics/pcbs/CBC_PCB/kicad/ESP32 SECTION.kicad_sch
@@ -6898,7 +6898,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:CC0402KRX7R7BB104")
+		(lib_id "EasyEDA_Lib:CC0402KRX7R7BB104")
 		(at 17.78 123.19 90)
 		(unit 1)
 		(body_style 1)
@@ -7426,7 +7426,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:CC0402KRX7R7BB104")
+		(lib_id "EasyEDA_Lib:CC0402KRX7R7BB104")
 		(at 186.69 139.7 90)
 		(unit 1)
 		(body_style 1)
@@ -7563,7 +7563,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:HGC0402R5105K250NTEJ")
+		(lib_id "EasyEDA_Lib:HGC0402R5105K250NTEJ")
 		(at 30.48 69.85 90)
 		(unit 1)
 		(body_style 1)
@@ -7857,7 +7857,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:ESP32-S3-WROOM-1(N16R8)")
+		(lib_id "EasyEDA_Lib:ESP32-S3-WROOM-1(N16R8)")
 		(at 109.22 52.07 0)
 		(unit 1)
 		(body_style 1)
@@ -8109,7 +8109,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:SS14_C7420316")
+		(lib_id "EasyEDA_Lib:SS14_C7420316")
 		(at 63.5 115.57 0)
 		(unit 1)
 		(body_style 1)
@@ -8712,7 +8712,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:TYPE-C 16PIN 2MD(073)")
+		(lib_id "EasyEDA_Lib:TYPE-C 16PIN 2MD(073)")
 		(at 35.56 132.08 180)
 		(unit 1)
 		(body_style 1)
@@ -8883,7 +8883,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:TS-1088-AR02016")
+		(lib_id "EasyEDA_Lib:TS-1088-AR02016")
 		(at 40.64 64.77 0)
 		(unit 1)
 		(body_style 1)
@@ -9253,7 +9253,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:MCS0402MC1001FE000")
+		(lib_id "EasyEDA_Lib:MCS0402MC1001FE000")
 		(at 52.07 26.67 90)
 		(unit 1)
 		(body_style 1)
@@ -9387,7 +9387,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:USBLC6-2SC6")
+		(lib_id "EasyEDA_Lib:USBLC6-2SC6")
 		(at 95.25 132.08 0)
 		(unit 1)
 		(body_style 1)
@@ -9534,7 +9534,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:0603 Green 509-620mcd")
+		(lib_id "EasyEDA_Lib:0603 Green 509-620mcd")
 		(at 52.07 38.1 90)
 		(unit 1)
 		(body_style 1)
@@ -9670,7 +9670,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:CC0402KRX7R7BB104")
+		(lib_id "EasyEDA_Lib:CC0402KRX7R7BB104")
 		(at 38.1 35.56 90)
 		(unit 1)
 		(body_style 1)
@@ -9807,7 +9807,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:GRM21BR61H106KE43L")
+		(lib_id "EasyEDA_Lib:GRM21BR61H106KE43L")
 		(at 30.48 35.56 90)
 		(unit 1)
 		(body_style 1)
@@ -9941,7 +9941,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:GRM21BR61H106KE43L")
+		(lib_id "EasyEDA_Lib:GRM21BR61H106KE43L")
 		(at 179.07 139.7 90)
 		(unit 1)
 		(body_style 1)
@@ -10467,7 +10467,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:UMH3N")
+		(lib_id "EasyEDA_Lib:UMH3N")
 		(at 232.41 140.97 0)
 		(unit 1)
 		(body_style 1)
@@ -10925,7 +10925,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:GRM21BR61H106KE43L")
+		(lib_id "EasyEDA_Lib:GRM21BR61H106KE43L")
 		(at 201.93 139.7 90)
 		(unit 1)
 		(body_style 1)
@@ -11137,7 +11137,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:0402WGF5101TCE")
+		(lib_id "EasyEDA_Lib:0402WGF5101TCE")
 		(at 57.15 146.05 90)
 		(unit 1)
 		(body_style 1)
@@ -11352,7 +11352,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:0402WGF5101TCE")
+		(lib_id "EasyEDA_Lib:0402WGF5101TCE")
 		(at 67.31 146.05 90)
 		(unit 1)
 		(body_style 1)
@@ -12581,7 +12581,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:CP2104-F03-GM")
+		(lib_id "EasyEDA_Lib:CP2104-F03-GM")
 		(at 144.78 138.43 0)
 		(unit 1)
 		(body_style 1)
@@ -12863,7 +12863,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:RT0402BRD0710KL")
+		(lib_id "EasyEDA_Lib:RT0402BRD0710KL")
 		(at 30.48 59.69 90)
 		(unit 1)
 		(body_style 1)
@@ -12997,7 +12997,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:CL21A475KBQNNNE")
+		(lib_id "EasyEDA_Lib:CL21A475KBQNNNE")
 		(at 20.32 34.29 90)
 		(unit 1)
 		(body_style 1)

--- a/engineering/electronics/pcbs/CBC_PCB/kicad/PERIPHERALS.kicad_sch
+++ b/engineering/electronics/pcbs/CBC_PCB/kicad/PERIPHERALS.kicad_sch
@@ -3299,7 +3299,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:CC0402KRX7R7BB104")
+		(lib_id "EasyEDA_Lib:CC0402KRX7R7BB104")
 		(at 68.58 171.45 90)
 		(unit 1)
 		(body_style 1)
@@ -3514,7 +3514,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:DS18B20Z+T&amp;R")
+		(lib_id "EasyEDA_Lib:DS18B20Z+T&amp;R")
 		(at 38.1 165.1 0)
 		(mirror y)
 		(unit 1)
@@ -4134,7 +4134,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:RC0402FR-074K7L")
+		(lib_id "EasyEDA_Lib:RC0402FR-074K7L")
 		(at 55.88 133.35 90)
 		(unit 1)
 		(body_style 1)
@@ -4425,7 +4425,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:DS18B20Z+T&amp;R")
+		(lib_id "EasyEDA_Lib:DS18B20Z+T&amp;R")
 		(at 36.83 134.62 0)
 		(mirror y)
 		(unit 1)
@@ -4655,7 +4655,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:RC0402FR-074K7L")
+		(lib_id "EasyEDA_Lib:RC0402FR-074K7L")
 		(at 57.15 163.83 90)
 		(unit 1)
 		(body_style 1)
@@ -4790,7 +4790,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:CC0402KRX7R7BB104")
+		(lib_id "EasyEDA_Lib:CC0402KRX7R7BB104")
 		(at 67.31 140.97 90)
 		(unit 1)
 		(body_style 1)
@@ -5316,7 +5316,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:AT13-12PB-BM03")
+		(lib_id "2026-04-30_07-21-07:AT13-12PB-BM03")
 		(at 31.75 38.1 0)
 		(unit 1)
 		(body_style 1)

--- a/engineering/electronics/pcbs/CBC_PCB/kicad/PERIPHERALS.kicad_sch
+++ b/engineering/electronics/pcbs/CBC_PCB/kicad/PERIPHERALS.kicad_sch
@@ -35,7 +35,7 @@
 					)
 				)
 			)
-			(property "Footprint" "CONN_AT13-12X-BMXX_AMP"
+			(property "Footprint" "CBC_PCB:CONN_AT13-12X-BMXX_AMP"
 				(at 0 0 0)
 				(show_name no)
 				(do_not_autoplace no)
@@ -5346,7 +5346,7 @@
 				)
 			)
 		)
-		(property "Footprint" "CONN_AT13-12X-BMXX_AMP"
+		(property "Footprint" "CBC_PCB:CONN_AT13-12X-BMXX_AMP"
 			(at 31.75 38.1 0)
 			(hide yes)
 			(show_name no)

--- a/engineering/electronics/pcbs/CBC_PCB/kicad/POWER REGULATOR.kicad_sch
+++ b/engineering/electronics/pcbs/CBC_PCB/kicad/POWER REGULATOR.kicad_sch
@@ -12218,7 +12218,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:GRM31CC72A475KE11L")
+		(lib_id "EasyEDA_Lib:GRM31CC72A475KE11L")
 		(at 269.24 140.97 90)
 		(unit 1)
 		(body_style 1)
@@ -12354,7 +12354,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:ERJ1KM2R2D11OT")
+		(lib_id "EasyEDA_Lib:ERJ1KM2R2D11OT")
 		(at 33.02 40.64 270)
 		(unit 1)
 		(body_style 1)
@@ -12565,7 +12565,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:TAJB106K025RNJ")
+		(lib_id "EasyEDA_Lib:TAJB106K025RNJ")
 		(at 248.92 43.18 90)
 		(unit 1)
 		(body_style 1)
@@ -12776,7 +12776,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:CL10B104KC8NNNC")
+		(lib_id "EasyEDA_Lib:CL10B104KC8NNNC")
 		(at 240.03 44.45 270)
 		(unit 1)
 		(body_style 1)
@@ -12910,7 +12910,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:GRM31CC72A475KE11L")
+		(lib_id "EasyEDA_Lib:GRM31CC72A475KE11L")
 		(at 41.91 85.09 90)
 		(unit 1)
 		(body_style 1)
@@ -13200,7 +13200,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:SP015N03BGHTO")
+		(lib_id "EasyEDA_Lib:SP015N03BGHTO")
 		(at 142.24 128.27 0)
 		(unit 1)
 		(body_style 1)
@@ -13433,7 +13433,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:FSV10150V")
+		(lib_id "EasyEDA_Lib:FSV10150V")
 		(at 100.33 43.18 270)
 		(unit 1)
 		(body_style 1)
@@ -13727,7 +13727,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:0603WAF6042T5E")
+		(lib_id "EasyEDA_Lib:0603WAF6042T5E")
 		(at 22.86 134.62 90)
 		(unit 1)
 		(body_style 1)
@@ -13864,7 +13864,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:ERJ1KM2R2D11OT")
+		(lib_id "EasyEDA_Lib:ERJ1KM2R2D11OT")
 		(at 59.69 85.09 270)
 		(unit 1)
 		(body_style 1)
@@ -13998,7 +13998,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:CC0805KRX7R0BB471")
+		(lib_id "EasyEDA_Lib:CC0805KRX7R0BB471")
 		(at 34.29 134.62 90)
 		(unit 1)
 		(body_style 1)
@@ -14134,7 +14134,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:GRM31CR61E476ME44L")
+		(lib_id "EasyEDA_Lib:GRM31CR61E476ME44L")
 		(at 246.38 113.03 90)
 		(unit 1)
 		(body_style 1)
@@ -14271,7 +14271,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:GRM31CR61E476ME44L")
+		(lib_id "EasyEDA_Lib:GRM31CR61E476ME44L")
 		(at 191.77 113.03 90)
 		(unit 1)
 		(body_style 1)
@@ -14486,7 +14486,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:GCM1885C2A121FA16D")
+		(lib_id "EasyEDA_Lib:GCM1885C2A121FA16D")
 		(at 144.78 95.25 90)
 		(unit 1)
 		(body_style 1)
@@ -14621,7 +14621,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:RT0603BRE07240KL")
+		(lib_id "EasyEDA_Lib:RT0603BRE07240KL")
 		(at 118.11 39.37 90)
 		(unit 1)
 		(body_style 1)
@@ -14755,7 +14755,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:GRM31CR61E476ME44L")
+		(lib_id "EasyEDA_Lib:GRM31CR61E476ME44L")
 		(at 212.09 113.03 90)
 		(unit 1)
 		(body_style 1)
@@ -15281,7 +15281,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:CMMR1U-02 TR PBFREE")
+		(lib_id "EasyEDA_Lib:CMMR1U-02 TR PBFREE")
 		(at 134.62 95.25 270)
 		(unit 1)
 		(body_style 1)
@@ -15417,7 +15417,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:ERJ1KM2R2D11OT")
+		(lib_id "EasyEDA_Lib:ERJ1KM2R2D11OT")
 		(at 22.86 40.64 270)
 		(unit 1)
 		(body_style 1)
@@ -15551,7 +15551,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:RT0603BRD0710KL")
+		(lib_id "EasyEDA_Lib:RT0603BRD0710KL")
 		(at 118.11 54.61 90)
 		(unit 1)
 		(body_style 1)
@@ -15764,7 +15764,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:FRC0603F2371TS")
+		(lib_id "EasyEDA_Lib:FRC0603F2371TS")
 		(at 212.09 162.56 0)
 		(unit 1)
 		(body_style 1)
@@ -16053,7 +16053,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:0805W8F300KT5E")
+		(lib_id "EasyEDA_Lib:0805W8F300KT5E")
 		(at 135.89 134.62 0)
 		(unit 1)
 		(body_style 1)
@@ -16187,7 +16187,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:FRC0603F7501TS")
+		(lib_id "EasyEDA_Lib:FRC0603F7501TS")
 		(at 43.18 133.35 90)
 		(unit 1)
 		(body_style 1)
@@ -16324,7 +16324,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:GRM31CC72A475KE11L")
+		(lib_id "EasyEDA_Lib:GRM31CC72A475KE11L")
 		(at 118.11 115.57 90)
 		(unit 1)
 		(body_style 1)
@@ -16537,7 +16537,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:GRM31CC72A475KE11L")
+		(lib_id "EasyEDA_Lib:GRM31CC72A475KE11L")
 		(at 35.56 85.09 90)
 		(unit 1)
 		(body_style 1)
@@ -16673,7 +16673,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:ERA6AEB680V")
+		(lib_id "EasyEDA_Lib:ERA6AEB680V")
 		(at 125.73 110.49 0)
 		(unit 1)
 		(body_style 1)
@@ -17041,7 +17041,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:LT8309ES5#TRMPBF")
+		(lib_id "EasyEDA_Lib:LT8309ES5#TRMPBF")
 		(at 247.65 147.32 180)
 		(unit 1)
 		(body_style 1)
@@ -17576,7 +17576,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:CL10B224KB8NNNC")
+		(lib_id "EasyEDA_Lib:CL10B224KB8NNNC")
 		(at 55.88 134.62 90)
 		(unit 1)
 		(body_style 1)
@@ -17713,7 +17713,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:ERJ1KM2R2D11OT")
+		(lib_id "EasyEDA_Lib:ERJ1KM2R2D11OT")
 		(at 278.13 113.03 270)
 		(unit 1)
 		(body_style 1)
@@ -17926,7 +17926,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:CL21A475KBQNNNE")
+		(lib_id "EasyEDA_Lib:CL21A475KBQNNNE")
 		(at 146.05 41.91 90)
 		(unit 1)
 		(body_style 1)
@@ -18142,7 +18142,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:ERJ1KM2R2D11OT")
+		(lib_id "EasyEDA_Lib:ERJ1KM2R2D11OT")
 		(at 267.97 113.03 270)
 		(unit 1)
 		(body_style 1)
@@ -18433,7 +18433,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:ZEMS0850-330M")
+		(lib_id "EasyEDA_Lib:ZEMS0850-330M")
 		(at 110.49 34.29 0)
 		(unit 1)
 		(body_style 1)
@@ -18644,7 +18644,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:CL10B104KC8NNNC")
+		(lib_id "EasyEDA_Lib:CL10B104KC8NNNC")
 		(at 194.31 41.91 90)
 		(unit 1)
 		(body_style 1)
@@ -18778,7 +18778,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:0805W8F1603T5E")
+		(lib_id "EasyEDA_Lib:0805W8F1603T5E")
 		(at 85.09 106.68 0)
 		(unit 1)
 		(body_style 1)
@@ -19066,7 +19066,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:PA1736NL")
+		(lib_id "EasyEDA_Lib:PA1736NL")
 		(at 173.99 118.11 0)
 		(unit 1)
 		(body_style 1)
@@ -19232,7 +19232,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:AMS1117-3.3")
+		(lib_id "EasyEDA_Lib:AMS1117-3.3")
 		(at 267.97 36.83 0)
 		(unit 1)
 		(body_style 1)
@@ -19450,7 +19450,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:SMBJ5365B-TP")
+		(lib_id "EasyEDA_Lib:SMBJ5365B-TP")
 		(at 213.36 149.86 270)
 		(unit 1)
 		(body_style 1)
@@ -19663,7 +19663,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:RT0603BRD0710KL")
+		(lib_id "EasyEDA_Lib:RT0603BRD0710KL")
 		(at 182.88 40.64 90)
 		(unit 1)
 		(body_style 1)
@@ -19797,7 +19797,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:GRM31CC72A475KE11L")
+		(lib_id "EasyEDA_Lib:GRM31CC72A475KE11L")
 		(at 48.26 85.09 90)
 		(unit 1)
 		(body_style 1)
@@ -19933,7 +19933,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:GRM31CR61E476ME44L")
+		(lib_id "EasyEDA_Lib:GRM31CR61E476ME44L")
 		(at 19.05 85.09 90)
 		(unit 1)
 		(body_style 1)
@@ -20225,7 +20225,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:SP015N03BGHTO")
+		(lib_id "EasyEDA_Lib:SP015N03BGHTO")
 		(at 200.66 130.81 0)
 		(mirror y)
 		(unit 1)
@@ -20458,7 +20458,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:BAV20W-7-F")
+		(lib_id "EasyEDA_Lib:BAV20W-7-F")
 		(at 135.89 110.49 0)
 		(unit 1)
 		(body_style 1)
@@ -20827,7 +20827,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:CL10B104KC8NNNC")
+		(lib_id "EasyEDA_Lib:CL10B104KC8NNNC")
 		(at 130.81 43.18 90)
 		(unit 1)
 		(body_style 1)
@@ -20961,7 +20961,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:0603WAF6041T5E")
+		(lib_id "EasyEDA_Lib:0603WAF6041T5E")
 		(at 15.24 134.62 90)
 		(unit 1)
 		(body_style 1)
@@ -21097,7 +21097,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:SMBJ85A-13-F")
+		(lib_id "EasyEDA_Lib:SMBJ85A-13-F")
 		(at 134.62 85.09 90)
 		(unit 1)
 		(body_style 1)
@@ -21233,7 +21233,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:TAJB106K025RNJ")
+		(lib_id "EasyEDA_Lib:TAJB106K025RNJ")
 		(at 229.87 44.45 90)
 		(unit 1)
 		(body_style 1)
@@ -21367,7 +21367,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:GRM31CR61E476ME44L")
+		(lib_id "EasyEDA_Lib:GRM31CR61E476ME44L")
 		(at 236.22 113.03 90)
 		(unit 1)
 		(body_style 1)
@@ -21504,7 +21504,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:SMBJ5.0CA_C83323")
+		(lib_id "EasyEDA_Lib:SMBJ5.0CA_C83323")
 		(at 204.47 41.91 90)
 		(unit 1)
 		(body_style 1)
@@ -21640,7 +21640,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:CL10B333KB8NNNC")
+		(lib_id "EasyEDA_Lib:CL10B333KB8NNNC")
 		(at 43.18 142.24 90)
 		(unit 1)
 		(body_style 1)
@@ -21854,7 +21854,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:YLRY06-1-10F")
+		(lib_id "EasyEDA_Lib:YLRY06-1-10F")
 		(at 144.78 142.24 90)
 		(unit 1)
 		(body_style 1)
@@ -22067,7 +22067,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:PTFR0603B100RN9")
+		(lib_id "EasyEDA_Lib:PTFR0603B100RN9")
 		(at 144.78 85.09 90)
 		(unit 1)
 		(body_style 1)
@@ -22667,7 +22667,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:GRM31CR61E476ME44L")
+		(lib_id "EasyEDA_Lib:GRM31CR61E476ME44L")
 		(at 226.06 113.03 90)
 		(unit 1)
 		(body_style 1)
@@ -22881,7 +22881,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:XAL6030-102MEC")
+		(lib_id "EasyEDA_Lib:XAL6030-102MEC")
 		(at 219.71 104.14 0)
 		(unit 1)
 		(body_style 1)
@@ -23093,7 +23093,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:CL21A475KBQNNNE")
+		(lib_id "EasyEDA_Lib:CL21A475KBQNNNE")
 		(at 165.1 38.1 90)
 		(unit 1)
 		(body_style 1)
@@ -23622,7 +23622,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:PTFR0603B51K0P9")
+		(lib_id "EasyEDA_Lib:PTFR0603B51K0P9")
 		(at 73.66 95.25 90)
 		(unit 1)
 		(body_style 1)
@@ -23988,7 +23988,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:MP9486GN-Z")
+		(lib_id "MP9486GN-Z:MP9486GN-Z")
 		(at 48.26 30.48 0)
 		(unit 1)
 		(body_style 1)
@@ -24400,7 +24400,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:AC0603KRX7R0BB472")
+		(lib_id "EasyEDA_Lib:AC0603KRX7R0BB472")
 		(at 166.37 146.05 0)
 		(unit 1)
 		(body_style 1)
@@ -24613,7 +24613,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:CC0805KKX7R0BB105")
+		(lib_id "EasyEDA_Lib:CC0805KKX7R0BB105")
 		(at 224.79 149.86 90)
 		(unit 1)
 		(body_style 1)
@@ -25064,7 +25064,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:CL10B104KC8NNNC")
+		(lib_id "EasyEDA_Lib:CL10B104KC8NNNC")
 		(at 220.98 45.72 270)
 		(unit 1)
 		(body_style 1)
@@ -25198,7 +25198,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:PTFR0603B140KP9")
+		(lib_id "EasyEDA_Lib:PTFR0603B140KP9")
 		(at 182.88 29.21 90)
 		(unit 1)
 		(body_style 1)
@@ -25333,7 +25333,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:PSPMAA1082T-220M-CGP")
+		(lib_id "EasyEDA_Lib:PSPMAA1082T-220M-CGP")
 		(at 27.94 80.01 0)
 		(unit 1)
 		(body_style 1)
@@ -25544,7 +25544,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:LT3748EMS#PBF")
+		(lib_id "EasyEDA_Lib:LT3748EMS#PBF")
 		(at 86.36 123.19 0)
 		(mirror y)
 		(unit 1)
@@ -25709,7 +25709,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:FRC0805F1204TS")
+		(lib_id "EasyEDA_Lib:FRC0805F1204TS")
 		(at 73.66 85.09 90)
 		(unit 1)
 		(body_style 1)
@@ -25921,7 +25921,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:CL10C470JB8NNNC")
+		(lib_id "EasyEDA_Lib:CL10C470JB8NNNC")
 		(at 125.73 138.43 90)
 		(unit 1)
 		(body_style 1)
@@ -26058,7 +26058,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:BAV20W-7-F")
+		(lib_id "EasyEDA_Lib:BAV20W-7-F")
 		(at 193.04 144.78 180)
 		(unit 1)
 		(body_style 1)
@@ -26192,7 +26192,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:RC0402FR-070RL")
+		(lib_id "EasyEDA_Lib:RC0402FR-070RL")
 		(at 113.03 128.27 0)
 		(unit 1)
 		(body_style 1)
@@ -26483,7 +26483,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:SMB5350B")
+		(lib_id "EasyEDA_Lib:SMB5350B")
 		(at 256.54 113.03 270)
 		(unit 1)
 		(body_style 1)
@@ -26619,7 +26619,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:CL10B104KC8NNNC")
+		(lib_id "EasyEDA_Lib:CL10B104KC8NNNC")
 		(at 69.85 15.24 180)
 		(unit 1)
 		(body_style 1)
@@ -26753,7 +26753,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:GRM31CR61E476ME44L")
+		(lib_id "EasyEDA_Lib:GRM31CR61E476ME44L")
 		(at 201.93 113.03 90)
 		(unit 1)
 		(body_style 1)
@@ -27124,7 +27124,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:CL21A475KBQNNNE")
+		(lib_id "EasyEDA_Lib:CL21A475KBQNNNE")
 		(at 153.67 38.1 90)
 		(unit 1)
 		(body_style 1)
@@ -27261,7 +27261,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:0805W8F300KT5E")
+		(lib_id "EasyEDA_Lib:0805W8F300KT5E")
 		(at 204.47 144.78 0)
 		(unit 1)
 		(body_style 1)

--- a/engineering/electronics/pcbs/CBC_PCB/kicad/POWER REGULATOR.kicad_sch
+++ b/engineering/electronics/pcbs/CBC_PCB/kicad/POWER REGULATOR.kicad_sch
@@ -9062,7 +9062,7 @@
 					)
 				)
 			)
-			(property "Footprint" "SOIC-8EP_MP9486_MNP"
+			(property "Footprint" "CBC_PCB:SOIC-8EP_MP9486_MNP"
 				(at 0 0 0)
 				(show_name no)
 				(do_not_autoplace no)
@@ -24019,7 +24019,7 @@
 				)
 			)
 		)
-		(property "Footprint" "SOIC-8EP_MP9486_MNP"
+		(property "Footprint" "CBC_PCB:SOIC-8EP_MP9486_MNP"
 			(at 48.26 30.48 0)
 			(hide yes)
 			(show_name no)

--- a/engineering/electronics/pcbs/CBC_PCB/kicad/POWER SECTION.kicad_sch
+++ b/engineering/electronics/pcbs/CBC_PCB/kicad/POWER SECTION.kicad_sch
@@ -11033,7 +11033,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:74LVC1G17W5-7")
+		(lib_id "EasyEDA_Lib:74LVC1G17W5-7")
 		(at 90.17 113.03 0)
 		(unit 1)
 		(body_style 1)
@@ -11176,7 +11176,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:0154005.DR")
+		(lib_id "EasyEDA_Lib:0154005.DR")
 		(at 227.33 64.77 0)
 		(unit 1)
 		(body_style 1)
@@ -11310,7 +11310,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:SMBJ13CA_C19077568")
+		(lib_id "EasyEDA_Lib:SMBJ13CA_C19077568")
 		(at 152.4 116.84 90)
 		(unit 1)
 		(body_style 1)
@@ -11446,7 +11446,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:SMMS0650-101M")
+		(lib_id "EasyEDA_Lib:SMMS0650-101M")
 		(at 208.28 24.13 0)
 		(unit 1)
 		(body_style 1)
@@ -11580,7 +11580,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:SMBJ13CA_C19077568")
+		(lib_id "EasyEDA_Lib:SMBJ13CA_C19077568")
 		(at 300.99 118.11 90)
 		(unit 1)
 		(body_style 1)
@@ -12030,7 +12030,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:MCS0402MC1001FE000")
+		(lib_id "EasyEDA_Lib:MCS0402MC1001FE000")
 		(at 294.64 113.03 180)
 		(unit 1)
 		(body_style 1)
@@ -12632,7 +12632,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:RT0402BRD0710KL")
+		(lib_id "EasyEDA_Lib:RT0402BRD0710KL")
 		(at 166.37 116.84 90)
 		(unit 1)
 		(body_style 1)
@@ -12844,7 +12844,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:MCS0402MC1001FE000")
+		(lib_id "EasyEDA_Lib:MCS0402MC1001FE000")
 		(at 146.05 111.76 180)
 		(unit 1)
 		(body_style 1)
@@ -13134,7 +13134,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:RT0402BRD0710KL")
+		(lib_id "EasyEDA_Lib:RT0402BRD0710KL")
 		(at 207.01 118.11 90)
 		(unit 1)
 		(body_style 1)
@@ -13503,7 +13503,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:RC0402FR-07330RL")
+		(lib_id "EasyEDA_Lib:RC0402FR-07330RL")
 		(at 116.84 193.04 90)
 		(unit 1)
 		(body_style 1)
@@ -13793,7 +13793,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:CPC1106NTR")
+		(lib_id "EasyEDA_Lib:CPC1106NTR")
 		(at 111.76 213.36 270)
 		(unit 1)
 		(body_style 1)
@@ -13934,7 +13934,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:MCS0402MC1001FE000")
+		(lib_id "EasyEDA_Lib:MCS0402MC1001FE000")
 		(at 186.69 113.03 180)
 		(unit 1)
 		(body_style 1)
@@ -14302,7 +14302,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:SP015N03BGHTO")
+		(lib_id "EasyEDA_Lib:SP015N03BGHTO")
 		(at 354.838 105.41 270)
 		(mirror x)
 		(unit 1)
@@ -14770,7 +14770,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:LKME1252A101MF")
+		(lib_id "EasyEDA_Lib:LKME1252A101MF")
 		(at 153.162 40.894 0)
 		(unit 1)
 		(body_style 1)
@@ -15297,7 +15297,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:SP015N03BGHTO")
+		(lib_id "EasyEDA_Lib:SP015N03BGHTO")
 		(at 246.38 67.31 270)
 		(mirror x)
 		(unit 1)
@@ -15453,7 +15453,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:AMT0650009DB0000G")
+		(lib_id "AMT0650009DB0000G:AMT0650009DB0000G")
 		(at 24.13 60.96 0)
 		(unit 1)
 		(body_style 1)
@@ -15631,7 +15631,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:SP015N03BGHTO")
+		(lib_id "EasyEDA_Lib:SP015N03BGHTO")
 		(at 314.96 105.41 270)
 		(mirror x)
 		(unit 1)
@@ -15787,7 +15787,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:CPC1019NTR")
+		(lib_id "EasyEDA_Lib:CPC1019NTR")
 		(at 195.58 168.91 0)
 		(unit 1)
 		(body_style 1)
@@ -16005,7 +16005,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:SMBJ13CA_C19077568")
+		(lib_id "EasyEDA_Lib:SMBJ13CA_C19077568")
 		(at 193.04 118.11 90)
 		(unit 1)
 		(body_style 1)
@@ -16141,7 +16141,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:MCS0402MC1001FE000")
+		(lib_id "EasyEDA_Lib:MCS0402MC1001FE000")
 		(at 257.81 113.03 180)
 		(unit 1)
 		(body_style 1)
@@ -16431,7 +16431,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:SMBJ13CA_C19077568")
+		(lib_id "EasyEDA_Lib:SMBJ13CA_C19077568")
 		(at 228.6 118.11 90)
 		(unit 1)
 		(body_style 1)
@@ -16645,7 +16645,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:LKME1252A101MF")
+		(lib_id "EasyEDA_Lib:LKME1252A101MF")
 		(at 229.87 29.21 0)
 		(unit 1)
 		(body_style 1)
@@ -16780,7 +16780,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:C90D_PAD")
+		(lib_id "C90D_PAD:C90D_PAD")
 		(at 27.178 21.336 0)
 		(mirror y)
 		(unit 1)
@@ -16859,7 +16859,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:CL10B104KC8NNNC")
+		(lib_id "EasyEDA_Lib:CL10B104KC8NNNC")
 		(at 159.766 35.814 0)
 		(unit 1)
 		(body_style 1)
@@ -16993,7 +16993,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:A1257WV-S-2P")
+		(lib_id "EasyEDA_Lib:A1257WV-S-2P")
 		(at 68.58 23.368 90)
 		(unit 1)
 		(body_style 1)
@@ -17288,7 +17288,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:GRM21BR61H106KE43L")
+		(lib_id "EasyEDA_Lib:GRM21BR61H106KE43L")
 		(at 52.07 107.95 90)
 		(unit 1)
 		(body_style 1)
@@ -17422,7 +17422,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:AMT0650009DB0000G")
+		(lib_id "AMT0650009DB0000G:AMT0650009DB0000G")
 		(at 93.98 60.96 0)
 		(unit 1)
 		(body_style 1)
@@ -17677,7 +17677,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:MCS0402MC1001FE000")
+		(lib_id "EasyEDA_Lib:MCS0402MC1001FE000")
 		(at 334.518 113.03 180)
 		(unit 1)
 		(body_style 1)
@@ -17889,7 +17889,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:RT0603BRD07100KL")
+		(lib_id "EasyEDA_Lib:RT0603BRD07100KL")
 		(at 41.91 102.87 0)
 		(unit 1)
 		(body_style 1)
@@ -18023,7 +18023,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:RT0402BRD0710KL")
+		(lib_id "EasyEDA_Lib:RT0402BRD0710KL")
 		(at 242.57 118.11 90)
 		(unit 1)
 		(body_style 1)
@@ -18235,7 +18235,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:SP015N03BGHTO")
+		(lib_id "EasyEDA_Lib:SP015N03BGHTO")
 		(at 278.13 105.41 270)
 		(mirror x)
 		(unit 1)
@@ -18469,7 +18469,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:JER1206F1R060")
+		(lib_id "EasyEDA_Lib:JER1206F1R060")
 		(at 245.11 24.13 0)
 		(unit 1)
 		(body_style 1)
@@ -18603,7 +18603,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:RT0402BRD0710KL")
+		(lib_id "EasyEDA_Lib:RT0402BRD0710KL")
 		(at 48.26 198.12 90)
 		(unit 1)
 		(body_style 1)
@@ -18893,7 +18893,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:RT0402BRD073K3L")
+		(lib_id "EasyEDA_Lib:RT0402BRD073K3L")
 		(at 68.58 118.11 90)
 		(unit 1)
 		(body_style 1)
@@ -19184,7 +19184,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:RT0402BRD0710KL")
+		(lib_id "EasyEDA_Lib:RT0402BRD0710KL")
 		(at 68.58 107.95 90)
 		(unit 1)
 		(body_style 1)
@@ -19395,7 +19395,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:RT0603BRD072K7L")
+		(lib_id "EasyEDA_Lib:RT0603BRD072K7L")
 		(at 255.27 39.37 90)
 		(unit 1)
 		(body_style 1)
@@ -19608,7 +19608,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:SP015N03BGHTO")
+		(lib_id "EasyEDA_Lib:SP015N03BGHTO")
 		(at 242.57 105.41 270)
 		(mirror x)
 		(unit 1)
@@ -19921,7 +19921,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:GRM21BR61H106KE43L")
+		(lib_id "EasyEDA_Lib:GRM21BR61H106KE43L")
 		(at 96.52 191.77 90)
 		(unit 1)
 		(body_style 1)
@@ -20055,7 +20055,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:RT0402BRD0710KL")
+		(lib_id "EasyEDA_Lib:RT0402BRD0710KL")
 		(at 354.838 118.11 90)
 		(unit 1)
 		(body_style 1)
@@ -20345,7 +20345,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:SMBJ13CA_C19077568")
+		(lib_id "EasyEDA_Lib:SMBJ13CA_C19077568")
 		(at 264.16 118.11 90)
 		(unit 1)
 		(body_style 1)
@@ -20638,7 +20638,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:MAX810R")
+		(lib_id "EasyEDA_Lib:MAX810R")
 		(at 22.606 237.236 180)
 		(unit 1)
 		(body_style 1)
@@ -21322,7 +21322,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:AC05000003309JAC00")
+		(lib_id "EasyEDA_Lib:AC05000003309JAC00")
 		(at 261.62 67.31 0)
 		(unit 1)
 		(body_style 1)
@@ -21457,7 +21457,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:C90D_PAD")
+		(lib_id "C90D_PAD:C90D_PAD")
 		(at 93.98 21.59 0)
 		(unit 1)
 		(body_style 1)
@@ -21613,7 +21613,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:SP015N03BGHTO")
+		(lib_id "EasyEDA_Lib:SP015N03BGHTO")
 		(at 392.938 105.664 270)
 		(mirror x)
 		(unit 1)
@@ -21769,7 +21769,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:CL10B104KC8NNNC")
+		(lib_id "EasyEDA_Lib:CL10B104KC8NNNC")
 		(at 218.44 29.21 90)
 		(unit 1)
 		(body_style 1)
@@ -21903,7 +21903,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:RT0402BRD0710KL")
+		(lib_id "EasyEDA_Lib:RT0402BRD0710KL")
 		(at 314.96 118.11 90)
 		(unit 1)
 		(body_style 1)
@@ -22115,7 +22115,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:RT0402BRD0710KL")
+		(lib_id "EasyEDA_Lib:RT0402BRD0710KL")
 		(at 392.938 118.364 90)
 		(unit 1)
 		(body_style 1)
@@ -22249,7 +22249,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:MCS0402MC1001FE000")
+		(lib_id "EasyEDA_Lib:MCS0402MC1001FE000")
 		(at 226.06 74.93 180)
 		(unit 1)
 		(body_style 1)
@@ -22383,7 +22383,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:CL10B104KC8NNNC")
+		(lib_id "EasyEDA_Lib:CL10B104KC8NNNC")
 		(at 141.732 40.894 90)
 		(unit 1)
 		(body_style 1)
@@ -22517,7 +22517,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:RC0402FR-07330RL")
+		(lib_id "EasyEDA_Lib:RC0402FR-07330RL")
 		(at 166.37 64.77 180)
 		(unit 1)
 		(body_style 1)
@@ -22652,7 +22652,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:XL7056E1")
+		(lib_id "EasyEDA_Lib:XL7056E1")
 		(at 177.8 27.94 180)
 		(unit 1)
 		(body_style 1)
@@ -23431,7 +23431,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:RT0402BRD0710KL")
+		(lib_id "EasyEDA_Lib:RT0402BRD0710KL")
 		(at 278.13 118.11 90)
 		(unit 1)
 		(body_style 1)
@@ -23565,7 +23565,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:25121WF100JT4E")
+		(lib_id "EasyEDA_Lib:25121WF100JT4E")
 		(at 141.732 28.956 90)
 		(unit 1)
 		(body_style 1)
@@ -23701,7 +23701,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:AMT0650009DB0000G")
+		(lib_id "AMT0650009DB0000G:AMT0650009DB0000G")
 		(at 298.45 29.21 0)
 		(unit 1)
 		(body_style 1)
@@ -23879,7 +23879,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:RC0402FR-07330RL")
+		(lib_id "EasyEDA_Lib:RC0402FR-07330RL")
 		(at 171.45 163.83 180)
 		(unit 1)
 		(body_style 1)
@@ -24014,7 +24014,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:FSV10150V")
+		(lib_id "EasyEDA_Lib:FSV10150V")
 		(at 203.2 29.21 270)
 		(unit 1)
 		(body_style 1)
@@ -24153,7 +24153,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:GRM21BR61H106KE43L")
+		(lib_id "EasyEDA_Lib:GRM21BR61H106KE43L")
 		(at 115.57 115.57 90)
 		(unit 1)
 		(body_style 1)
@@ -24444,7 +24444,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:SMBJ13CA_C19077568")
+		(lib_id "EasyEDA_Lib:SMBJ13CA_C19077568")
 		(at 232.41 80.01 90)
 		(unit 1)
 		(body_style 1)
@@ -24580,7 +24580,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:AMT0650009DB0000G")
+		(lib_id "AMT0650009DB0000G:AMT0650009DB0000G")
 		(at 355.6 29.21 0)
 		(unit 1)
 		(body_style 1)
@@ -24913,7 +24913,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:SP015N03BGHTO")
+		(lib_id "EasyEDA_Lib:SP015N03BGHTO")
 		(at 207.01 105.41 270)
 		(mirror x)
 		(unit 1)
@@ -25069,7 +25069,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:SMBJ13CA_C19077568")
+		(lib_id "EasyEDA_Lib:SMBJ13CA_C19077568")
 		(at 378.968 118.364 90)
 		(unit 1)
 		(body_style 1)
@@ -25595,7 +25595,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:RT0402BRD0710KL")
+		(lib_id "EasyEDA_Lib:RT0402BRD0710KL")
 		(at 246.38 80.01 90)
 		(unit 1)
 		(body_style 1)
@@ -25807,7 +25807,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:SMBJ13CA_C19077568")
+		(lib_id "EasyEDA_Lib:SMBJ13CA_C19077568")
 		(at 340.868 118.11 90)
 		(unit 1)
 		(body_style 1)
@@ -25943,7 +25943,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:CPC1106NTR")
+		(lib_id "EasyEDA_Lib:CPC1106NTR")
 		(at 185.42 69.85 0)
 		(unit 1)
 		(body_style 1)
@@ -26239,7 +26239,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:AC05000003309JAC00")
+		(lib_id "EasyEDA_Lib:AC05000003309JAC00")
 		(at 261.62 63.5 0)
 		(unit 1)
 		(body_style 1)
@@ -26373,7 +26373,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:74LVC2G02HK3-7")
+		(lib_id "EasyEDA_Lib:74LVC2G02HK3-7")
 		(at 64.77 190.5 0)
 		(unit 1)
 		(body_style 1)
@@ -26525,7 +26525,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:MCS0402MC1001FE000")
+		(lib_id "EasyEDA_Lib:MCS0402MC1001FE000")
 		(at 372.618 113.284 180)
 		(unit 1)
 		(body_style 1)
@@ -26736,7 +26736,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:MCS0402MC1001FE000")
+		(lib_id "EasyEDA_Lib:MCS0402MC1001FE000")
 		(at 222.25 113.03 180)
 		(unit 1)
 		(body_style 1)
@@ -26870,7 +26870,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:ES3D_C241735")
+		(lib_id "EasyEDA_Lib:ES3D_C241735")
 		(at 254 75.946 90)
 		(unit 1)
 		(body_style 1)
@@ -27006,7 +27006,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:SP015N03BGHTO")
+		(lib_id "EasyEDA_Lib:SP015N03BGHTO")
 		(at 166.37 104.14 270)
 		(mirror x)
 		(unit 1)
@@ -27162,7 +27162,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:SMBJ78CA_C2903953")
+		(lib_id "EasyEDA_Lib:SMBJ78CA_C2903953")
 		(at 261.62 57.15 0)
 		(unit 1)
 		(body_style 1)
@@ -27296,7 +27296,7 @@
 		)
 	)
 	(symbol
-		(lib_id "CBC_PCB:0603WAF2372T5E")
+		(lib_id "EasyEDA_Lib:0603WAF2372T5E")
 		(at 255.27 29.21 90)
 		(unit 1)
 		(body_style 1)

--- a/engineering/electronics/pcbs/CBC_PCB/kicad/POWER SECTION.kicad_sch
+++ b/engineering/electronics/pcbs/CBC_PCB/kicad/POWER SECTION.kicad_sch
@@ -33,7 +33,7 @@
 					(justify left top)
 				)
 			)
-			(property "Footprint" "AMT0650009DB0000G"
+			(property "Footprint" "CBC_PCB:AMT0650009DB0000G"
 				(at 16.51 -94.92 0)
 				(show_name no)
 				(do_not_autoplace no)
@@ -15484,7 +15484,7 @@
 				)
 			)
 		)
-		(property "Footprint" "AMT0650009DB0000G"
+		(property "Footprint" "CBC_PCB:AMT0650009DB0000G"
 			(at 40.64 155.88 0)
 			(hide yes)
 			(show_name no)
@@ -17453,7 +17453,7 @@
 				)
 			)
 		)
-		(property "Footprint" "AMT0650009DB0000G"
+		(property "Footprint" "CBC_PCB:AMT0650009DB0000G"
 			(at 110.49 155.88 0)
 			(hide yes)
 			(show_name no)
@@ -23732,7 +23732,7 @@
 				)
 			)
 		)
-		(property "Footprint" "AMT0650009DB0000G"
+		(property "Footprint" "CBC_PCB:AMT0650009DB0000G"
 			(at 314.96 124.13 0)
 			(hide yes)
 			(show_name no)
@@ -24611,7 +24611,7 @@
 				)
 			)
 		)
-		(property "Footprint" "AMT0650009DB0000G"
+		(property "Footprint" "CBC_PCB:AMT0650009DB0000G"
 			(at 372.11 124.13 0)
 			(hide yes)
 			(show_name no)

--- a/engineering/electronics/pcbs/CBC_PCB/kicad/fp-lib-table
+++ b/engineering/electronics/pcbs/CBC_PCB/kicad/fp-lib-table
@@ -1,4 +1,5 @@
 (fp_lib_table
 	(version 7)
 	(lib (name "CBC_PCB") (type "KiCad") (uri "${KIPRJMOD}/libs/CBC_PCB.pretty") (options "") (descr "CBC project footprints"))
+	(lib (name "C90D_PAD") (type "KiCad") (uri "${KIPRJMOD}/libs/CBC_PCB.pretty") (options "") (descr "Imported C90D pad footprint"))
 )

--- a/engineering/electronics/pcbs/CBC_PCB/kicad/sym-lib-table
+++ b/engineering/electronics/pcbs/CBC_PCB/kicad/sym-lib-table
@@ -3,6 +3,7 @@
 	(lib (name "CBC_PCB") (type "KiCad") (uri "${KIPRJMOD}/libs/CBC_PCB.kicad_sym") (options "") (descr "CBC project symbols"))
 	(lib (name "EasyEDA_Lib") (type "KiCad") (uri "${KIPRJMOD}/libs/CBC_PCB.kicad_sym") (options "") (descr "Imported EasyEDA/JLCEDA symbols"))
 	(lib (name "AMT0650009DB0000G") (type "KiCad") (uri "${KIPRJMOD}/libs/CBC_PCB.kicad_sym") (options "") (descr "Imported connector symbols"))
+	(lib (name "C90D_PAD") (type "KiCad") (uri "${KIPRJMOD}/libs/CBC_PCB.kicad_sym") (options "") (descr "Imported C90D pad symbols"))
 	(lib (name "2026-04-30_07-21-07") (type "KiCad") (uri "${KIPRJMOD}/libs/CBC_PCB.kicad_sym") (options "") (descr "Imported AT13 connector symbols"))
 	(lib (name "2026-05-07_02-52-27") (type "KiCad") (uri "${KIPRJMOD}/libs/CBC_PCB.kicad_sym") (options "") (descr "Imported MP9486 symbols"))
 )

--- a/engineering/electronics/pcbs/CBC_PCB/kicad/sym-lib-table
+++ b/engineering/electronics/pcbs/CBC_PCB/kicad/sym-lib-table
@@ -1,4 +1,8 @@
 (sym_lib_table
 	(version 7)
 	(lib (name "CBC_PCB") (type "KiCad") (uri "${KIPRJMOD}/libs/CBC_PCB.kicad_sym") (options "") (descr "CBC project symbols"))
+	(lib (name "EasyEDA_Lib") (type "KiCad") (uri "${KIPRJMOD}/libs/CBC_PCB.kicad_sym") (options "") (descr "Imported EasyEDA/JLCEDA symbols"))
+	(lib (name "AMT0650009DB0000G") (type "KiCad") (uri "${KIPRJMOD}/libs/CBC_PCB.kicad_sym") (options "") (descr "Imported connector symbols"))
+	(lib (name "2026-04-30_07-21-07") (type "KiCad") (uri "${KIPRJMOD}/libs/CBC_PCB.kicad_sym") (options "") (descr "Imported AT13 connector symbols"))
+	(lib (name "2026-05-07_02-52-27") (type "KiCad") (uri "${KIPRJMOD}/libs/CBC_PCB.kicad_sym") (options "") (descr "Imported MP9486 symbols"))
 )


### PR DESCRIPTION
## Summary

This PR fixes the CBC KiCad import so KiCad can resolve the schematic symbols and footprints during schematic refresh / PCB update.

### What changed

- Restored the imported schematic symbol references to their original library nicknames where appropriate:
  - `EasyEDA_Lib:*` for the EasyEDA/JLCEDA parts
  - `C90D_PAD:C90D_PAD` for the custom C90D pad symbol
  - the imported connector/regulator symbol library nicknames for the non-EasyEDA custom parts
- Added project-local library-table aliases so those nicknames resolve without requiring the original external EasyEDA library package:
  - `sym-lib-table` maps the imported symbol library names to `libs/CBC_PCB.kicad_sym`
  - `fp-lib-table` maps `C90D_PAD` to `libs/CBC_PCB.pretty`
- Qualified the previously unqualified footprint fields so KiCad stops warning during refresh:
  - `J2` → `CBC_PCB:CONN_AT13-12X-BMXX_AMP`
  - `J4/J5/J6/J7` → `CBC_PCB:AMT0650009DB0000G`
  - `U23` → `CBC_PCB:SOIC-8EP_MP9486_MNP`

### Why this approach

The first import tried to consolidate too aggressively into `CBC_PCB:*`. That broke KiCad's cached imported symbols because the schematic sheets still contain symbol definitions under their original imported library names. This update keeps the imported EasyEDA/custom library names in the schematic, but points those names at the project-local symbol/footprint libraries so the project remains self-contained.

## Validation

- Verified every non-power schematic symbol reference has a matching cached symbol definition in its sheet.
- Verified no CBC schematic `Footprint` properties are missing a library prefix.
- `kicad-cli sch export netlist engineering/electronics/pcbs/CBC_PCB/kicad/CBC_PCB.kicad_sch -o /tmp/cbc.net` passes.
- `kicad-cli pcb export step engineering/electronics/pcbs/CBC_PCB/kicad/CBC_PCB.kicad_pcb -o /tmp/cbc.step` passes.
  - It still warns about missing `C1206_L3.2-W1.6-H1.3.step` models, which appears to be inherited from the source package rather than introduced here.
- GitHub sanity checks are green.
