### PR TITLE
Docs site: project intro, system architecture, and electronics pages

### DIFF
--- a/.cspell.project-words.txt
+++ b/.cspell.project-words.txt
@@ -61,3 +61,11 @@ UAVCAN
 VBUS
 SMTSO
 edcd
+BRWZ
+GNSS
+JWPF
+PSRAM
+WROOM
+Xtensa
+multirotor
+pinouts

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -15,23 +15,20 @@ This page covers the parts of the architecture that are documented in the reposi
 
 ## Architecture at a Glance
 
-```
-                    ┌─────────────── Central Core ───────────────┐
-                    │  Flight controller (ArduPilot)              │
-                    │  CMAIN PCB — LV distribution + CAN hub      │
-                    │  Payload interfaces                         │
-                    └──────┬──────────────────────────────────────┘
-                           │ harness per arm: isolated 12V,
-                           │ DroneCAN, kill/control signals
-        ┌──────────────────┴──────────────────┐
-        │           Motor Arm (×6)            │
-        │  Tattu 4.0 18S battery              │
-        │    → C90D adapter PCB               │
-        │    → CBC PCB (fuse, precharge,      │
-        │       kill, regulation, dual CAN)   │
-        │    → Hobbywing X15 motor + ESC      │
-        │       with 63" propeller            │
-        └─────────────────────────────────────┘
+```text
+CENTRAL CORE
+  - Flight controller (ArduPilot)
+  - CMAIN PCB (LV distribution + CAN hub)
+  - Payload interfaces
+      |
+      |  harness per arm: isolated 12V,
+      |  DroneCAN, kill/control signals
+      |
+MOTOR ARM (x6)
+  Tattu 4.0 18S battery
+   -> C90D adapter PCB
+   -> CBC PCB (fuse, precharge, kill, regulation, dual CAN)
+   -> Hobbywing X15 motor + ESC with 63" propeller
 ```
 
 ## Propulsion

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,70 @@
+---
+title: System Architecture
+sidebar_label: Architecture
+sidebar_position: 2
+description: How Project Caribou is put together — airframe, propulsion, power, electronics, and avionics
+---
+
+# System Architecture
+
+Caribou is a ~200 kg MTOW hexacopter organized around a simple structural idea: **six independent motor arms around a central core**. Each arm is a self-contained power unit — battery, power electronics, motor — and the core carries the avionics, low-voltage distribution, and payload.
+
+:::note
+This page covers the parts of the architecture that are documented in the repository today. Some areas (notably the structure and detailed avionics configuration) are still being written up as PT1 progresses — see the [PT1 status](./index.md#development-status) on the intro page.
+:::
+
+## Architecture at a Glance
+
+```
+                    ┌─────────────── Central Core ───────────────┐
+                    │  Flight controller (ArduPilot)              │
+                    │  CMAIN PCB — LV distribution + CAN hub      │
+                    │  Payload interfaces                         │
+                    └──────┬──────────────────────────────────────┘
+                           │ harness per arm: isolated 12V,
+                           │ DroneCAN, kill/control signals
+        ┌──────────────────┴──────────────────┐
+        │           Motor Arm (×6)            │
+        │  Tattu 4.0 18S battery              │
+        │    → C90D adapter PCB               │
+        │    → CBC PCB (fuse, precharge,      │
+        │       kill, regulation, dual CAN)   │
+        │    → Hobbywing X15 motor + ESC      │
+        │       with 63" propeller            │
+        └─────────────────────────────────────┘
+```
+
+## Propulsion
+
+Six Hobbywing XRotor X15 integrated propulsion units (motor + ESC) with 63" (1600 mm) propellers, rated by Hobbywing at 32.5–37.5 kg working thrust and up to 72 kg maximum thrust per rotor. Hover sits around 50% throttle (~45 A per motor); full throttle draws close to 200 A per motor, which drives the current ratings throughout the power path.
+
+ESCs take CAN and PWM signal inputs, connected to CMAIN via sealed automotive-grade connectors.
+
+## Power
+
+**Per-arm, no shared HV bus.** Each arm has its own 18S Tattu 4.0 smart battery (64.8 V nominal, 75.6 V max) feeding only its own motor through its own [CBC board](./electronics/cbc.md). PT1 flies at 18S; the platform is specified for an 18–24S architecture.
+
+Key properties of the power design:
+
+- **Fused and switched per arm** — 250 A ceramic fuse, MOSFET precharge and main-enable stages on every CBC
+- **Hardware kill chain** — an external HV kill switch feeds every CBC through the harness and cuts motor power at the MOSFET stage, independent of firmware
+- **Isolated low-voltage system** — each CBC generates a galvanically isolated 12 V / 10 A output; these feed the aircraft LV system through CMAIN, so aircraft-side faults cannot back-feed into any battery power path
+- **Smart battery telemetry** — each CBC reads its pack over the battery's CAN protocol and republishes telemetry on DroneCAN, so the autopilot monitors all six packs with standard battery monitors
+
+## Electronics
+
+Three custom KiCad-designed boards — CBC (×6), C90D (×6), and CMAIN (×1) — covered in detail in the [Electronics section](./electronics/index.md).
+
+## Avionics
+
+- **ArduPilot** flight stack, compatible with QGroundControl and Mission Planner
+- **Triple-redundant IMU, GPS, and compass**
+- **DroneCAN** as the aircraft-wide bus for battery telemetry and ESC communication, routed through CMAIN
+
+## Structure
+
+The airframe uses a welded steel/aluminum core structure with detachable motor arms (carbon fiber or aluminum) for transport and field service. The PT1 test frame is built; structural documentation (materials, dimensions, analysis) is part of the in-progress PT1 engineering report.
+
+## Design Lineage
+
+Caribou deliberately reuses proven patterns from earlier Arrow aircraft: the CBC evolved from Quiver's battery connector PCB, CMAIN merges the Feather PDB with Quiver's main PCB, and the smart-battery + DroneCAN approach extends what Quiver established. Where Caribou differs is scale — per-arm batteries instead of a central pack, an order of magnitude more thrust per rotor, and high-voltage safety hardware (kill chain, precharge, isolation) sized accordingly.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -35,7 +35,7 @@ MOTOR ARM (x6)
 
 Six Hobbywing XRotor X15 integrated propulsion units (motor + ESC) with 63" (1600 mm) propellers, rated by Hobbywing at 32.5–37.5 kg working thrust and up to 72 kg maximum thrust per rotor. Hover sits around 50% throttle (~45 A per motor); full throttle draws close to 200 A per motor, which drives the current ratings throughout the power path.
 
-ESCs take CAN and PWM signal inputs, connected to CMAIN via sealed automotive-grade connectors.
+ESCs take CAN and PWM signal inputs, connected to CMAIN via waterproof JST JWPF connectors.
 
 ## Power
 

--- a/docs/electronics/_category_.json
+++ b/docs/electronics/_category_.json
@@ -1,0 +1,8 @@
+{
+  "label": "Electronics",
+  "position": 3,
+  "link": {
+    "type": "doc",
+    "id": "electronics/index"
+  }
+}

--- a/docs/electronics/c90d.md
+++ b/docs/electronics/c90d.md
@@ -7,7 +7,7 @@ description: The 90° adapter PCB between the battery connector and the CBC asse
 
 # C90D — 90° Battery Adapter PCB
 
-The C90D is a mechanical and electrical adapter between the main battery connector and the [CBC](./cbc) assembly. It changes the battery connector orientation by 90° to suit the motor-arm packaging while carrying the full propulsion power path.
+The C90D is a mechanical and electrical adapter between the main battery connector and the [CBC](./cbc.md) assembly. It changes the battery connector orientation by 90° to suit the motor-arm packaging while carrying the full propulsion power path.
 
 Source: [`engineering/electronics/pcbs/C90D_PCB/`](https://github.com/Arrow-air/project-caribou/tree/main/engineering/electronics/pcbs/C90D_PCB) · Tracking issue: [#19](https://github.com/Arrow-air/project-caribou/issues/19)
 

--- a/docs/electronics/c90d.md
+++ b/docs/electronics/c90d.md
@@ -1,0 +1,24 @@
+---
+title: C90D — 90° Battery Adapter PCB
+sidebar_label: C90D (Battery Adapter)
+sidebar_position: 3
+description: The 90° adapter PCB between the battery connector and the CBC assembly
+---
+
+# C90D — 90° Battery Adapter PCB
+
+The C90D is a mechanical and electrical adapter between the main battery connector and the [CBC](./cbc) assembly. It changes the battery connector orientation by 90° to suit the motor-arm packaging while carrying the full propulsion power path.
+
+Source: [`engineering/electronics/pcbs/C90D_PCB/`](https://github.com/Arrow-air/project-caribou/tree/main/engineering/electronics/pcbs/C90D_PCB) · Tracking issue: [#19](https://github.com/Arrow-air/project-caribou/issues/19)
+
+## What It Does
+
+1. **Battery-side interface** — mates with the main battery connector (ACES 59626)
+2. **CBC-side interface** — right-angle power connection into the CBC assembly via OT-201-M8 screw terminals
+3. **High-current path** — carries the Hobbywing X15 drive current (150 A design target, pending detailed validation)
+4. **Battery CAN passthrough** — dedicated CAN connector (JST GH series)
+5. **Mechanical support** — mounting holes secure the adapter and connector assembly
+
+## Design Notes
+
+Because the board is a pure power/signal passthrough, the design work is dominated by physical constraints: copper weight, current path geometry, connector ratings, thermal rise, and mechanical assembly — all checked against the 150 A target.

--- a/docs/electronics/cbc.md
+++ b/docs/electronics/cbc.md
@@ -27,7 +27,7 @@ Source: [`engineering/electronics/pcbs/CBC_PCB/`](https://github.com/Arrow-air/p
 | Parameter | Value |
 |---|---|
 | Battery configuration | 18S (64.8 V nominal, 75.6 V max) |
-| Continuous current | 100 A |
+| Continuous current | 150 A (in line with the C90D power path) |
 | Spike current | 200 A (short duration) |
 | Main fuse | 250 A ceramic bolt-in |
 | Isolated output | 12 V / 10 A (GNDE) |
@@ -41,7 +41,7 @@ The current ratings are derived from Hobbywing X15 motor data: roughly 45 A per 
 
 The CBC has two independent CAN interfaces:
 
-- **CAN 1 — Battery** — private bus to the Tattu 4.0 smart battery
+- **CAN 1 — Battery** — private bus to the Tattu 4.0 smart battery. This interface is galvanically isolated, so the battery-side CAN domain stays separate from the board logic
 - **CAN 2 — DroneCAN** — aircraft-wide bus to the flight controller via CMAIN
 
 Firmware decodes the battery pack telemetry (voltage, current, state of charge, cell data, temperatures) and republishes it as standard DroneCAN battery messages, so the autopilot sees each pack as a normal DroneCAN battery monitor. CAN termination is jumper-selectable and open by default.

--- a/docs/electronics/cbc.md
+++ b/docs/electronics/cbc.md
@@ -1,0 +1,57 @@
+---
+title: CBC — Battery Connector PCB
+sidebar_label: CBC (Battery Connector)
+sidebar_position: 2
+description: The Caribou Battery Connector PCB — power switching, protection, regulation, and dual CAN per motor arm
+---
+
+# CBC — Caribou Battery Connector PCB
+
+The CBC sits between an 18S Tattu 4.0 smart battery and a Hobbywing X15 propulsion unit. Each of the six motor arms carries one CBC. It is the safety-critical board in the power path: nothing flows from a battery to a motor except through a CBC.
+
+Source: [`engineering/electronics/pcbs/CBC_PCB/`](https://github.com/Arrow-air/project-caribou/tree/main/engineering/electronics/pcbs/CBC_PCB) · Tracking issue: [#6](https://github.com/Arrow-air/project-caribou/issues/6)
+
+## What It Does
+
+1. **Battery mating** — mates directly with the Tattu 4.0 battery connector (via the [C90D adapter](./c90d.md)). Battery-present detection pins must be bridged for the pack to power on
+2. **Short-circuit protection** — 250 A ceramic bolt-in fuse (Eaton AMXL-250)
+3. **Active power switching** — MOSFET stage with three functions:
+   - *Precharge* — soft-starts the ESC input capacitors through a resistor before the main path closes, limiting inrush current
+   - *Main power enable* — low-Rdson parallel MOSFETs connect the HV bus to the propulsion output
+   - *Kill switch* — hardware-level cutoff driven by the aircraft's external HV kill switch, independent of the MCU
+4. **Voltage regulation** — 5 V / 3.3 V rails for onboard logic (GNDI, non-isolated) and a galvanically isolated 12 V / 10 A output (GNDE) that powers the aircraft's low-voltage system through CMAIN
+5. **Dual CAN** — battery protocol on one bus, DroneCAN on the other, bridged in firmware
+
+## Key Specifications
+
+| Parameter | Value |
+|---|---|
+| Battery configuration | 18S (64.8 V nominal, 75.6 V max) |
+| Continuous current | 100 A |
+| Spike current | 200 A (short duration) |
+| Main fuse | 250 A ceramic bolt-in |
+| Isolated output | 12 V / 10 A (GNDE) |
+| MCU | ESP32-S3-WROOM-1 |
+| CAN controllers | 2× MCP2515 on shared SPI |
+| EDA tool | KiCad |
+
+The current ratings are derived from Hobbywing X15 motor data: roughly 45 A per motor at hover throttle (~50%), ~100 A at 72% throttle, and ~197 A at full throttle.
+
+## Dual CAN Bridge
+
+The CBC has two independent CAN interfaces:
+
+- **CAN 1 — Battery** — private bus to the Tattu 4.0 smart battery
+- **CAN 2 — DroneCAN** — aircraft-wide bus to the flight controller via CMAIN
+
+Firmware decodes the battery pack telemetry (voltage, current, state of charge, cell data, temperatures) and republishes it as standard DroneCAN battery messages, so the autopilot sees each pack as a normal DroneCAN battery monitor. CAN termination is jumper-selectable and open by default.
+
+## Firmware
+
+Firmware for the ESP32-S3 is in review ([PR #54](https://github.com/Arrow-air/project-caribou/pull/54)): switch control (precharge/enable/kill sensing), dual-CAN drivers, Tattu battery telemetry decode, and the DroneCAN bridge.
+
+Bench validation (July 2026) on the manufactured boards: full Tattu telemetry decode on real hardware, and two CBCs connected to a flight controller successfully completed DroneCAN dynamic node allocation, with battery voltage/SoC/temperature visible in Mission Planner via standard `BATT_MONITOR` DroneCAN configuration.
+
+## Status
+
+Manufactured CBC boards were delivered in mid-July 2026 and are in bench bring-up, with enclosures printed. See the board's [`docs/`](https://github.com/Arrow-air/project-caribou/tree/main/engineering/electronics/pcbs/CBC_PCB/docs) folder for the power architecture, connector pinout, and schematic review notes.

--- a/docs/electronics/cmain.md
+++ b/docs/electronics/cmain.md
@@ -1,0 +1,32 @@
+---
+title: CMAIN — Main PCB
+sidebar_label: CMAIN (Main PCB)
+sidebar_position: 4
+description: The Caribou Main PCB — central low-voltage avionics hub for all six motor arms
+---
+
+# CMAIN — Caribou Main PCB
+
+CMAIN is the central hub of the Caribou electrical system. It merges the roles of the Feather PDB and the Quiver main PCB: low-voltage power distribution, CAN routing, ESC signal outputs, and sensor connections for the whole aircraft. High-voltage/high-current handling is deliberately out of scope — that lives on the [CBC](./cbc.md) boards at each arm.
+
+Source: [`engineering/electronics/pcbs/CMAIN_PCB/`](https://github.com/Arrow-air/project-caribou/tree/main/engineering/electronics/pcbs/CMAIN_PCB) · Tracking issue: [#8](https://github.com/Arrow-air/project-caribou/issues/8)
+
+## Interfaces
+
+| Quantity | Connector | Purpose |
+|---|---|---|
+| 6 | Amphenol AT13-12PB-BM03 | One per CBC — isolated 12 V in, DroneCAN, kill/control signals |
+| 6 | Amphenol AT13-6P-BM01GRY | One per ESC — CAN H, CAN L, PWM, GND |
+
+The AT series is an automotive-grade sealed connector family chosen for vibration resistance and field serviceability. Additional external sensor and payload connectors (following Quiver's pattern of radar, LiDAR, camera, and attachment interfaces) are still being defined — compact waterproof M8 circular connectors are the leading candidate for low-current sensor ports.
+
+## Scope
+
+- Aggregates six isolated 12 V feeds from the CBCs into the aircraft low-voltage system
+- Routes the aircraft-wide DroneCAN network between CBCs, ESCs, and the flight controller
+- Provides ESC signal interfaces (CAN + PWM) for the six Hobbywing X15 propulsion units
+- Central-frame form factor, mounted in the aircraft core
+
+## Status
+
+CMAIN boards are manufactured and were delivered in July 2026, with 3D-printed enclosures complete. Detailed docs — connector requirements, routing rules, footprint audits, and design proposals — live in the board's [`docs/`](https://github.com/Arrow-air/project-caribou/tree/main/engineering/electronics/pcbs/CMAIN_PCB/docs) folder.

--- a/docs/electronics/cmain.md
+++ b/docs/electronics/cmain.md
@@ -15,10 +15,10 @@ Source: [`engineering/electronics/pcbs/CMAIN_PCB/`](https://github.com/Arrow-air
 
 | Quantity | Connector | Purpose |
 |---|---|---|
-| 6 | Amphenol AT13-12PB-BM03 | One per CBC — isolated 12 V in, DroneCAN, kill/control signals |
-| 6 | Amphenol AT13-6P-BM01GRY | One per ESC — CAN H, CAN L, PWM, GND |
+| 6 | JST JWPF 8-pin (B08B-JWPF-SK-R) | One per CBC — isolated 12 V in, DroneCAN, kill/control signals |
+| 6 | JST JWPF 4-pin (B04B-JWPF-SK-R) | One per Hobbywing X15 ESC — CAN H, CAN L, PWM, GND |
 
-The AT series is an automotive-grade sealed connector family chosen for vibration resistance and field serviceability. Additional external sensor and payload connectors (following Quiver's pattern of radar, LiDAR, camera, and attachment interfaces) are still being defined — compact waterproof M8 circular connectors are the leading candidate for low-current sensor ports.
+External wire-to-board interfaces use the JST JWPF waterproof connector family (an earlier Amphenol AT13 concept was dropped in favor of JST). Smaller JST GH connectors are used for internal signal-level connections. The board also carries sensor and payload interfaces per the schematic — GNSS (including a DroneCAN RTK option), front and altimeter radar, SIYI gimbal/camera, safety switch, and a companion computer header — plus auxiliary power outputs.
 
 ## Scope
 

--- a/docs/electronics/index.md
+++ b/docs/electronics/index.md
@@ -1,0 +1,50 @@
+---
+title: Electronics Overview
+sidebar_label: Overview
+sidebar_position: 1
+description: Overview of the Caribou custom electronics — CBC, C90D, and CMAIN boards
+---
+
+# Electronics Overview
+
+Caribou uses a small family of custom PCBs, all designed in KiCad and developed in the open in [`engineering/electronics/pcbs/`](https://github.com/Arrow-air/project-caribou/tree/main/engineering/electronics/pcbs). The architecture builds on the Feather PDB and Quiver PCB designs.
+
+## Board Family
+
+- **[CBC — Caribou Battery Connector PCB](./cbc.md)** (6 per aircraft, one per motor arm) — interfaces an 18S smart battery with a motor arm: power switching, protection, voltage regulation, and dual CAN communication
+- **[C90D — 90° Battery Adapter PCB](./c90d.md)** (6 per aircraft) — mechanical/electrical adapter between the battery connector and the CBC assembly
+- **[CMAIN — Caribou Main PCB](./cmain.md)** (1 per aircraft) — central low-voltage avionics hub connecting all six arms to the flight controller
+
+## Per-Arm Power Architecture
+
+Each of the six motor arms is an independent power unit:
+
+```
+Tattu 4.0 18S battery
+        │
+     [C90D]  90° adapter
+        │
+     [CBC]   fuse · precharge · kill · regulation · CAN
+      │  │
+      │  └── isolated 12V + DroneCAN + signals ──→ harness ──→ CMAIN
+      │
+   [Hobbywing X15]  motor + ESC
+```
+
+There is no shared high-voltage bus between arms — each battery feeds its own propulsion unit through its own CBC. The CBC's galvanically isolated 12V output feeds the aircraft's low-voltage system via CMAIN, so a fault on the aircraft LV bus cannot back-feed into the battery power path.
+
+## CAN Topology
+
+Two separate CAN domains:
+
+- **Battery CAN (per arm)** — each CBC talks to its own Tattu 4.0 smart battery on a private CAN bus, reading pack telemetry (voltage, current, state of charge, temperatures)
+- **DroneCAN (aircraft-wide)** — the CBCs, ESCs, and flight controller share the aircraft DroneCAN network, routed through CMAIN. Each CBC translates its battery's telemetry onto DroneCAN so the autopilot sees six standard battery monitors
+
+## Ground Domains
+
+The electronics maintain strict ground-domain separation, labeled consistently across schematics and harnesses:
+
+- **GNDI** — internal, non-isolated logic ground on each CBC (MCU, CAN controllers)
+- **GNDE** — isolated external ground for the aircraft power distribution (12V system)
+
+Deeper design detail — connector pinouts, power architecture, requirements, and review notes — lives with each board in the repository and in the pages linked above.

--- a/docs/electronics/index.md
+++ b/docs/electronics/index.md
@@ -19,16 +19,16 @@ Caribou uses a small family of custom PCBs, all designed in KiCad and developed 
 
 Each of the six motor arms is an independent power unit:
 
-```
+```text
 Tattu 4.0 18S battery
-        │
-     [C90D]  90° adapter
-        │
-     [CBC]   fuse · precharge · kill · regulation · CAN
-      │  │
-      │  └── isolated 12V + DroneCAN + signals ──→ harness ──→ CMAIN
-      │
-   [Hobbywing X15]  motor + ESC
+        |
+     [C90D]  90-degree adapter
+        |
+     [CBC]   fuse / precharge / kill / regulation / CAN
+      |   \
+      |    \-- isolated 12V + DroneCAN + signals --> harness --> CMAIN
+      |
+ [Hobbywing X15]  motor + ESC
 ```
 
 There is no shared high-voltage bus between arms — each battery feeds its own propulsion unit through its own CBC. The CBC's galvanically isolated 12V output feeds the aircraft's low-voltage system via CMAIN, so a fault on the aircraft LV bus cannot back-feed into the battery power path.

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,7 +18,7 @@ All design files and documentation are released under the [CERN Open Hardware Li
 ## Key Capabilities
 
 - **Heavy lift** — ~100 kg payload capacity for cargo delivery or ~80 L liquid spraying missions
-- **Powerful COTS propulsion** — 6× Hobbywing XRotor X15 propulsion units with 63" (1600 mm) propellers
+- **Powerful COTS propulsion** — 6× Hobbywing XRotor X15 propulsion units with 63" (1600 mm) propellers, rated at up to 72 kg maximum thrust per rotor
 - **High-voltage architecture** — 18S (~75 V) power system for PT1 with Tattu smart batteries, external HV kill switch, pre-charge circuitry, and redundant power supply
 - **Custom electronics** — purpose-built battery connector PCB (CBC) and main PCB (CMAIN) handling power distribution, battery telemetry, and safety switching
 - **Redundant avionics** — triple-redundant IMU, GPS, and compass running ArduPilot, compatible with QGroundControl and Mission Planner
@@ -39,6 +39,7 @@ As of mid-2026:
 - The PT1 frame structure is built
 - CMAIN and CBC PCBs are manufactured, with 3D-printed enclosures complete
 - First motor tests are the next step, leading toward hover testing
+- A second build is planned in Texas to validate reproducibility
 - PT2 concept brainstorming is underway on the [DAO forum](https://dao.arrowair.com)
 
 Progress is discussed in weekly Caribou calls; notes are posted in the repository and on Discord.

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,23 +11,22 @@ description: Introduction to Project Caribou
 
 Project Caribou is an open-source heavy-lift hexacopter for cargo logistics and precision agriculture, developed by [Arrow](https://arrowair.com). With a target maximum takeoff weight of ~200 kg and ~100 kg of payload capacity, Caribou is designed to take on work currently flown by helicopters and light aircraft — large-area spraying, spreading, and heavy cargo delivery — at a fraction of the operating cost.
 
-Caribou builds directly on lessons from Project Feather and Project Quiver: distributed custom PCBs, CAN-based smart battery telemetry, companion computer integration, and a design philosophy centered on ruggedness, field repairability, and cost-effective manufacturing.
+Caribou builds directly on lessons from Project Feather and Project Quiver: distributed custom PCBs, CAN-based smart battery telemetry, and a design philosophy centered on ruggedness, field repairability, and cost-effective manufacturing.
 
 All design files and documentation are released under the [CERN Open Hardware Licence v2 — Strongly Reciprocal](https://ohwr.org/cern_ohl_s_v2.txt).
 
 ## Key Capabilities
 
 - **Heavy lift** — ~100 kg payload capacity for cargo delivery or ~80 L liquid spraying missions
-- **Powerful COTS propulsion** — 6× Hobbywing XRotor X15 propulsion units with 63" (1600 mm) propellers, delivering over 70 kg of maximum thrust per motor
-- **High-voltage architecture** — 18S (~75 V) power system with Tattu smart batteries, external HV kill switch, pre-charge circuitry, and redundant power supply
+- **Powerful COTS propulsion** — 6× Hobbywing XRotor X15 propulsion units with 63" (1600 mm) propellers
+- **High-voltage architecture** — 18S (~75 V) power system for PT1 with Tattu smart batteries, external HV kill switch, pre-charge circuitry, and redundant power supply
 - **Custom electronics** — purpose-built battery connector PCB (CBC) and main PCB (CMAIN) handling power distribution, battery telemetry, and safety switching
 - **Redundant avionics** — triple-redundant IMU, GPS, and compass running ArduPilot, compatible with QGroundControl and Mission Planner
 - **Hybrid airframe** — welded steel/aluminum core structure with detachable motor arms for transport and field service
-- **Companion computer support** — onboard data aggregation and logging, with a web-based ground station following the Quiver Hub pattern
 
 ## Why Caribou
 
-Agricultural spraying and spreading jobs at this scale are flown today with helicopters and fixed-wing aircraft. A heavy-lift multirotor that can be trucked to a field, assembled by a small crew, and operated at far lower cost per flight hour opens that work to many more operators. Early mission simulations suggest a Caribou can reach break-even on airframe cost within a small number of commercial jobs.
+Agricultural spraying and spreading jobs at this scale are flown today with helicopters and fixed-wing aircraft. A heavy-lift multirotor that can be trucked to a field, assembled by a small crew, and operated at far lower cost per flight hour opens that work to many more operators.
 
 For Arrow, Caribou is also a milestone: it is the largest aircraft the DAO has built, and a deliberate step on the roadmap from small drones toward larger — and eventually manned — aircraft.
 
@@ -40,7 +39,6 @@ As of mid-2026:
 - The PT1 frame structure is built
 - CMAIN and CBC PCBs are manufactured, with 3D-printed enclosures complete
 - First motor tests are the next step, leading toward hover testing
-- A second build is planned in Texas to validate reproducibility
 - PT2 concept brainstorming is underway on the [DAO forum](https://dao.arrowair.com)
 
 Progress is discussed in weekly Caribou calls; notes are posted in the repository and on Discord.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,69 @@
+---
+title: Intro
+sidebar_label: Intro
+sidebar_position: 1
+description: Introduction to Project Caribou
+---
+
+# Project Caribou
+
+![Project Caribou](./images/caribou_render.png)
+
+Project Caribou is an open-source heavy-lift hexacopter for cargo logistics and precision agriculture, developed by [Arrow](https://arrowair.com). With a target maximum takeoff weight of ~200 kg and ~100 kg of payload capacity, Caribou is designed to take on work currently flown by helicopters and light aircraft — large-area spraying, spreading, and heavy cargo delivery — at a fraction of the operating cost.
+
+Caribou builds directly on lessons from Project Feather and Project Quiver: distributed custom PCBs, CAN-based smart battery telemetry, companion computer integration, and a design philosophy centered on ruggedness, field repairability, and cost-effective manufacturing.
+
+All design files and documentation are released under the [CERN Open Hardware Licence v2 — Strongly Reciprocal](https://ohwr.org/cern_ohl_s_v2.txt).
+
+## Key Capabilities
+
+- **Heavy lift** — ~100 kg payload capacity for cargo delivery or ~80 L liquid spraying missions
+- **Powerful COTS propulsion** — 6× Hobbywing XRotor X15 propulsion units with 63" (1600 mm) propellers, delivering over 70 kg of maximum thrust per motor
+- **High-voltage architecture** — 18S (~75 V) power system with Tattu smart batteries, external HV kill switch, pre-charge circuitry, and redundant power supply
+- **Custom electronics** — purpose-built battery connector PCB (CBC) and main PCB (CMAIN) handling power distribution, battery telemetry, and safety switching
+- **Redundant avionics** — triple-redundant IMU, GPS, and compass running ArduPilot, compatible with QGroundControl and Mission Planner
+- **Hybrid airframe** — welded steel/aluminum core structure with detachable motor arms for transport and field service
+- **Companion computer support** — onboard data aggregation and logging, with a web-based ground station following the Quiver Hub pattern
+
+## Why Caribou
+
+Agricultural spraying and spreading jobs at this scale are flown today with helicopters and fixed-wing aircraft. A heavy-lift multirotor that can be trucked to a field, assembled by a small crew, and operated at far lower cost per flight hour opens that work to many more operators. Early mission simulations suggest a Caribou can reach break-even on airframe cost within a small number of commercial jobs.
+
+For Arrow, Caribou is also a milestone: it is the largest aircraft the DAO has built, and a deliberate step on the roadmap from small drones toward larger — and eventually manned — aircraft.
+
+## Development Status
+
+Caribou is in the **PT1 (proof of concept)** phase. The PT1 goal is to validate the structural design and high-voltage power architecture, with a stable tethered hover as the milestone.
+
+As of mid-2026:
+
+- The PT1 frame structure is built
+- CMAIN and CBC PCBs are manufactured, with 3D-printed enclosures complete
+- First motor tests are the next step, leading toward hover testing
+- A second build is planned in Texas to validate reproducibility
+- PT2 concept brainstorming is underway on the [DAO forum](https://dao.arrowair.com)
+
+Progress is discussed in weekly Caribou calls; notes are posted in the repository and on Discord.
+
+## Repository Structure
+
+```
+project-caribou/
+├── engineering/            # Active design work
+│   ├── cad/                # CAD sources, reference geometry, exports
+│   └── electronics/        # Self-contained KiCad PCB projects
+│       └── pcbs/
+│           ├── CBC_PCB/    # Battery connector PCB (+ firmware)
+│           └── CMAIN_PCB/  # Main PCB
+├── docs/                   # This documentation site
+│   └── pt1/                # PT1 engineering report, manufacturing & user guides
+└── src/                    # General source area
+```
+
+## Get Involved
+
+- **Discord** — [discord.gg/arrow](https://discord.gg/arrow), `#project-caribou-general`
+- **DAO Forum** — [dao.arrowair.com](https://dao.arrowair.com)
+- **GitHub** — [Arrow-air/project-caribou](https://github.com/Arrow-air/project-caribou)
+
+Caribou is developed in the open. Design discussions, test results, and decisions happen in public — contributions, questions, and reviews are welcome.

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,7 +18,7 @@ All design files and documentation are released under the [CERN Open Hardware Li
 ## Key Capabilities
 
 - **Heavy lift** — ~100 kg payload capacity for cargo delivery or ~80 L liquid spraying missions
-- **Powerful COTS propulsion** — 6× Hobbywing XRotor X15 propulsion units with 63" (1600 mm) propellers, rated at up to 72 kg maximum thrust per rotor
+- **Powerful off-the-shelf propulsion** — 6× Hobbywing XRotor X15 propulsion units with 63" (1600 mm) propellers, rated at up to 72 kg maximum thrust per rotor
 - **High-voltage architecture** — 18S (~75 V) power system for PT1 with Tattu smart batteries, external HV kill switch, pre-charge circuitry, and redundant power supply
 - **Custom electronics** — purpose-built battery connector PCB (CBC) and main PCB (CMAIN) handling power distribution, battery telemetry, and safety switching
 - **Redundant avionics** — triple-redundant IMU, GPS, and compass running ArduPilot, compatible with QGroundControl and Mission Planner

--- a/docs/pt1/001-engineering-report/engineering-report.md
+++ b/docs/pt1/001-engineering-report/engineering-report.md
@@ -1,3 +1,8 @@
+---
+title: PT1 Engineering Report
+draft: true
+---
+
 # Caribou PT1 Engineering Report
 
 **Status:** In progress  

--- a/docs/pt1/002-manufacturing-guides/structural-assembly.md
+++ b/docs/pt1/002-manufacturing-guides/structural-assembly.md
@@ -1,3 +1,8 @@
+---
+title: Structural Assembly Guide
+draft: true
+---
+
 # Structural Assembly Guide — PT1
 
 **Status:** In progress  

--- a/docs/pt1/003-user-guides/maintenance-guide.md
+++ b/docs/pt1/003-user-guides/maintenance-guide.md
@@ -1,3 +1,8 @@
+---
+title: Maintenance Guide
+draft: true
+---
+
 # Maintenance Guide — PT1
 
 **Status:** In progress  

--- a/engineering/electronics/pcbs/CBC_PCB/README.md
+++ b/engineering/electronics/pcbs/CBC_PCB/README.md
@@ -17,14 +17,14 @@ Each of the 6 motor arms has:
 - 1× Hobbywing XRotor X15 motor + ESC
 
 The CBC board sits between the battery and the propulsion unit. It provides:
-1. **Battery mating** — mates directly with the Tattu 4.0 battery connector
+1. **Battery interface** — receives battery power and battery CAN via the [C90D adapter PCB](../C90D_PCB/), which mates the Tattu 4.0 battery connector
 2. **Short-circuit protection** — 250A ceramic fuse
 3. **Active power switching** — precharge, kill switch, power enable via MOSFETs
 4. **Voltage regulation** — galvanically isolated 12V (GNDE) for the aircraft power distribution, plus non-isolated 5V/3.3V (GNDI) for onboard logic
 5. **Dual CAN bus** — battery protocol (CAN 1) and DroneCAN (CAN 2) as bridge
-6. **Wireless diagnostics** — WiFi/BLE via ESP32-C3 for configuration and monitoring
+6. **Wireless diagnostics** — WiFi/BLE via ESP32-S3 for configuration and monitoring
 
-The regulated 12V output (GNDE) feeds into the Caribou Main PCB ([CMAIN_PCB](../CMAIN_PCB/)) via the AT signal connector harness.
+The regulated 12V output (GNDE) feeds into the Caribou Main PCB ([CMAIN_PCB](../CMAIN_PCB/)) via the JST JWPF signal connector (J501) harness.
 
 ## Concept Renderings
 
@@ -41,8 +41,14 @@ Battery (18S Tattu 4.0)
         |
         v
 +---------------------+
-|  Battery Connector   |  ← Power (+ / −) + CAN L/H from battery
-|  (Prolanv EN60A)     |
+|  C90D Adapter PCB    |  ← Separate board: mates the battery connector,
+|  (../C90D_PCB/)      |     bridges present-detect pins
++---------------------+
+        |
+        v
++---------------------+
+|  Power Entry Pads    |  ← Power (+ / −) via HC201/HC202 pads,
+|  + Battery CAN       |     CAN L/H from battery via CN201
 +---------------------+
 |  AMXL-250 Fuse       |  ← 250A short-circuit protection
 +---------------------+
@@ -64,8 +70,8 @@ Battery (18S Tattu 4.0)
 |  3.3V          |     |
 |  (GNDI)        |     |
 +---------------------+
-|  AT Signal Connector |  ← 12V (GNDE), DroneCAN, signals
-|  (AT13-12PB-BM03)   |     to aircraft harness → CMAIN_PCB
+|  JST JWPF Connector  |  ← 12V (GNDE), DroneCAN, signals
+|  (J501, 8-pos)       |     to aircraft harness → CMAIN_PCB
 +---------------------+
 ```
 
@@ -76,7 +82,7 @@ Battery (18S Tattu 4.0)
 | Configuration | 18S (18 series cell groups) |
 | Max Voltage | 75.6V (4.2V × 18) |
 | Nominal Voltage | 64.8V (3.6V × 18) |
-| Continuous Current | 100A |
+| Continuous Current | 150A (in line with the C90D power path) |
 | Spike Current | 200A (short duration) |
 | Board Shape | Rectangular |
 | EDA Tool | KiCad 10 |
@@ -92,41 +98,22 @@ Based on the Hobbywing XRotor X15 motor data:
 | 72% | 47,933 g | 101.6 A |
 | 100% | 72,647 g | 197.1 A |
 
-Hover throttle is ~50%. The 100A nominal rating covers normal operations; the 200A spike rating handles full-throttle bursts.
+Hover throttle is ~50%. The 150A continuous rating covers normal operations with margin; the 200A spike rating handles full-throttle bursts.
 
 ## Connectors and Fuse
 
-### Battery Connector
+### Battery Interface (via C90D Adapter)
 
-**Mating Connector (Battery Side): ACES 59604-0169D-003**
+The CBC does not mate the battery directly. The Tattu 4.0 pack connector mates with the [C90D adapter PCB](../C90D_PCB/), which carries the battery connector (ACES 59626), bridges the battery-present detection pins, and adapts the connector orientation into the CBC assembly.
 
-This is the connector built into the Tattu 4.0 battery pack. The Prolanv EN60A on the CBC mates with this connector.
+From the C90D, the battery reaches the CBC through:
 
-| Position | Function | Notes |
+| Interface | Reference | Function |
 |---|---|---|
-| Left bank (red) | Anodal + (Positive) | Multiple parallel power contacts |
-| Right bank (blue) | Cathode − (Negative) | Multiple parallel power contacts |
-| Center top | CAN H + CAN L | Battery communication bus |
-| PIN1 + PIN2 (center bottom) | Battery Present Detection | Must be shorted (bridged) for the battery to power on |
+| Power entry pads | HC201 (`H_PWR-IN`), HC202 (`H_PWR-IN--PREFUSE`) | High-current + / − power path from the C90D |
+| Battery CAN connector | CN201 (A1257WV-S-2P, 2-pin GH-compatible) | `CANH_BAT` / `CANL_BAT` to the isolated battery CAN interface |
 
-> **Important:** PIN1 and PIN2 must be short-circuited by the mating connector (Prolanv EN60A) to signal "battery present" — the battery will not power on without this bridge. The CBC must include a trace or jumper connecting these two pins on the EN60A side.
-
-**Board-Side Connector: Prolanv EN60A**
-
-| Parameter | Value |
-|---|---|
-| Current per Power Pair | 60A |
-| Power Pairs | 5 positive + 5 negative |
-| Total Current Capacity | 300A |
-| Signal Pins | 6 |
-| Contact Resistance | 0.6 mΩ |
-| Mating Cycles | 10,000 |
-| Temperature Range | −40°C to +125°C |
-| Mounting | Right-Angle DIP (PCB mount) |
-
-The EN60A provides 300A total capacity across 5 power pairs, giving comfortable headroom above the 200A spike requirement. From the 6 signal pins, only 4 are used.
-
-At 200A spike across 4 power pairs (50A each): P = I² × R = 50² × 0.0006 = 1.5W per pair = 6W total — well within thermal limits.
+> **Note:** the battery-present detection bridge (required for the Tattu pack to power on) lives on the C90D side — see the C90D documentation for connector and mating details.
 
 ### Propulsion Screw Terminals
 
@@ -148,20 +135,22 @@ Two sets of AMT0650009DB0000G screw terminals are used on the board: one pair fo
 
 ### Signal Connector (Drone Interface)
 
-**Selected: Amphenol AT13-12PB-BM03 (or similar AT series)**
+**Selected: JST B08B-JWPF-SK-R (J501)**
 
-This connector interfaces the CBC with the rest of the Caribou electrical system via a wiring harness to the [CMAIN_PCB](../CMAIN_PCB/).
+This connector interfaces the CBC with the rest of the Caribou electrical system via a wiring harness to the [CMAIN_PCB](../CMAIN_PCB/). The JWPF series is a waterproof wire-to-board connector family; an earlier Amphenol AT13 concept was dropped in favor of JST.
 
-| Parameter | Value |
-|---|---|
-| Series | Amphenol AT (automotive-grade) |
-| Type | Right-Angle Flange Mount PCB Receptacle |
-| Positions | 12 |
-| Keying | B |
-| Contact Plating | Tin |
-| Mating Connector | AT series cable plug (wire-to-board) |
+| Pin | Signal | Function |
+|---|---|---|
+| 1 | GNDE | Isolated ground |
+| 2 | GNDE | Isolated ground |
+| 3 | 12V_ISOLATED | Isolated 12V output to aircraft LV system |
+| 4 | 12V_ISOLATED | Isolated 12V output to aircraft LV system |
+| 5 | CANL_DRONE | DroneCAN low |
+| 6 | CANH_DRONE | DroneCAN high |
+| 7 | 12V_TRIGGER_SIG | Kill switch trigger signal |
+| 8 | 12V_SUPPLY | 12V supply input |
 
-The AT series is an automotive/industrial-grade connector family designed for harsh environments — vibration-resistant, sealed, and rated for high mating cycles. The 12 positions carry the isolated 12V output (GNDE), DroneCAN bus lines, and control signals to/from the Caribou avionics.
+The 8 positions carry the isolated 12V output (GNDE), the DroneCAN bus pair, and the kill/control signals to/from the Caribou avionics.
 
 ### Main Fuse (Short-Circuit Protection)
 
@@ -181,22 +170,18 @@ The 250A fuse rating provides short-circuit protection while allowing the full 2
 
 ## MCU and Communication
 
-### MCU: ESP32-C3-MINI-1
+### MCU: ESP32-S3-WROOM-1 (U301)
 
-The ESP32-C3-MINI-1 module is a compact RISC-V based microcontroller with integrated wireless connectivity. It includes a PCB antenna — no external antenna components are required. A keepout zone must be maintained around the antenna area on the PCB layout (no copper / ground plane underneath).
+The ESP32-S3-WROOM-1 module (N16R8 variant) is a dual-core microcontroller with integrated wireless connectivity. It includes a PCB antenna — no external antenna components are required. A keepout zone must be maintained around the antenna area on the PCB layout (no copper / ground plane underneath).
 
 | Parameter | Value |
 |---|---|
-| Core | 32-bit RISC-V, 160 MHz |
-| Flash | 4 MB (integrated) |
-| SRAM | 400 KB |
+| Core | 2× 32-bit Xtensa LX7, up to 240 MHz |
+| Flash | 16 MB (N16R8) |
+| PSRAM | 8 MB (N16R8) |
 | WiFi | 802.11 b/g/n (2.4 GHz) |
 | Bluetooth | BLE 5.0 |
-| GPIOs | 22 |
-| SPI | 3× (1 used for dual MCP2515) |
-| ADC | 6 channels, 12-bit |
 | Operating Voltage | 3.0–3.6V |
-| Deep Sleep Current | 5 µA |
 | Antenna | Integrated PCB antenna |
 
 ### Dual CAN Bus (2× MCP2515 + Transceiver)
@@ -205,22 +190,22 @@ Two independent CAN networks using external MCP2515 controllers on a shared SPI 
 
 | CAN Bus | Purpose | Controller | Transceiver |
 |---|---|---|---|
-| CAN 1 — Battery | Battery protocol (smart battery communication) | MCP2515 (SPI, CS1) | SN65HVD230 (3.3V) |
-| CAN 2 — Drone | DroneCAN (UAVCAN v0) interface to Caribou avionics | MCP2515 (SPI, CS2) | SN65HVD230 (3.3V) |
+| CAN 1 — Battery | Battery protocol (smart battery communication) | MCP2515 (U402, SPI, CS1) | ADM3053BRWZ (U404, galvanically isolated) |
+| CAN 2 — Drone | DroneCAN (UAVCAN v0) interface to Caribou avionics | MCP2515 (U401, SPI, CS2) | TJA1049T/3J (U403) |
 
-Each MCP2515 requires an 8 MHz crystal + 2× 22 pF load capacitors. 120 Ω termination resistors are optional (directly connected or selectable via solder jumper depending on bus topology).
+The battery CAN transceiver (ADM3053) has an integrated isolated DC-DC converter, so the battery-side CAN domain is galvanically isolated from the board logic. Each MCP2515 is clocked by a 16 MHz crystal (X401/X402). 120 Ω termination resistors are jumper-selectable and open by default.
 
-The board converts between the battery protocol (CAN 1) and DroneCAN (CAN 2) using `libcanard`. The DroneCAN bus connects via the AT signal connector through the wiring harness to the [CMAIN_PCB](../CMAIN_PCB/), which serves as the central avionics hub for all 6 motor arms.
+The board converts between the battery protocol (CAN 1) and DroneCAN (CAN 2). The DroneCAN bus connects via the J501 signal connector through the wiring harness to the [CMAIN_PCB](../CMAIN_PCB/), which serves as the central avionics hub for all 6 motor arms.
 
 ### Schematic Sheet Interfaces
 
 | Signal / rail | Source sheet | Destination sheet(s) | Direction / notes |
 |---|---|---|---|
-| `H_PWR-IN`, `H_PWR-IN-`, `H_PWR-IN--PREFUSE` | POWER SECTION | POWER SECTION / board power path | 18S battery high-current domain; main fuse is mounted on J4/J5. |
+| `H_PWR-IN`, `H_PWR-IN-`, `H_PWR-IN--PREFUSE` | POWER SECTION | POWER SECTION / board power path | 18S battery high-current domain; main fuse is mounted on two of the AMT screw terminals (J201–J204). |
 | `+5V` | POWER REGULATOR | ESP32 SECTION, CAN SECTION, PERIPHERALS | Internal non-isolated logic rail. |
 | `+3V3` | POWER REGULATOR | ESP32 SECTION, CAN SECTION, PERIPHERALS | ESP32, MCP2515, CAN transceivers, sensors. |
-| `12V_ISOLATED` | POWER REGULATOR | PERIPHERALS / AT13 connector | Isolated output to aircraft harness; add an output fuse before harness output. |
-| `ESP_ENABLE_SIGNAL` | ESP32 SECTION | POWER SECTION | ESP-controlled main MOSFET latch enable; default-low via `R16` 10k pulldown. |
+| `12V_ISOLATED` | POWER REGULATOR | PERIPHERALS / J501 connector | Isolated output to aircraft harness; add an output fuse before harness output. |
+| `ESP_ENABLE_SIGNAL` | ESP32 SECTION | POWER SECTION | ESP-controlled main MOSFET latch enable (latch: `U201` 74LVC2G02); latch output default-low via `R207` pulldown. |
 | `PRECHARGE_ESP_SIGNAL` | ESP32 SECTION | POWER SECTION | ESP-controlled precharge command. |
 | `SCHMITT_OUT` | POWER SECTION | ESP32 SECTION | Hardware kill/trigger state feedback to ESP32. |
 | `SCK`, `MOSI`, `MISO` | ESP32 SECTION / CAN SECTION | ESP32 ↔ dual MCP2515 | Shared SPI bus; `SCK`/`MOSI` from ESP32, `MISO` from MCP2515s. |
@@ -229,20 +214,22 @@ The board converts between the battery protocol (CAN 1) and DroneCAN (CAN 2) usi
 | `RESET1`, `RESET2` | ESP32 SECTION | CAN SECTION | MCP2515 resets from ESP32. |
 | `TEMP1_DQ`, `TEMP2_DQ` | ESP32 SECTION / PERIPHERALS | ESP32 ↔ temperature sensors | 1-Wire data nets; formerly `DATA1` / `DATA2`. |
 | `CANH_BAT`, `CANL_BAT` | CAN SECTION / POWER SECTION | Battery connector ↔ CAN 1 | Battery CAN pair only; no battery CAN ground is normally carried. |
-| `CANH_DRONE`, `CANL_DRONE` | CAN SECTION / PERIPHERALS | CAN 2 ↔ AT13 harness | DroneCAN pair to CMAIN_PCB; termination is jumper-selectable and normally open. |
+| `CANH_DRONE`, `CANL_DRONE` | CAN SECTION / PERIPHERALS | CAN 2 ↔ J501 harness | DroneCAN pair to CMAIN_PCB; termination is jumper-selectable and normally open. |
 | `GND_CA`, `GND_CB`, `GNDI`, `GNDE` | Multiple | Domain-specific returns | `GND_CA` is effectively unused unless battery CAN reference is later required. `GND_CB` may be tied with other CBC `GND_CB` references on CMAIN_PCB. |
 
 ### GPIO Allocation
 
-| Function | GPIOs | Notes |
+As routed on the ordered board (from the production netlist):
+
+| Function | Signal | ESP32-S3 GPIO |
 |---|---|---|
-| SPI Bus (shared) — SCK, MOSI, MISO | 3 | Directly routed to both MCP2515 |
-| MCP2515 #1 — CS1, INT1 | 2 | CAN 1 (Battery) |
-| MCP2515 #2 — CS2, INT2 | 2 | CAN 2 (Drone) |
-| Temperature Sensors | 2 | 1-Wire (e.g. DS18B20) or analog NTC via ADC |
-| Circuit Switching | 4 | MOSFET gate drive (precharge, kill switch, power enable) |
-| **Total Used** | **13** | |
-| **Remaining / Reserve** | **9** | Available for future expansion |
+| Precharge command | `PRECHARGE_ESP_SIGNAL` | IO4 |
+| Kill/trigger state feedback | `SCHMITT_OUT` | IO5 |
+| Main MOSFET latch enable | `ESP_ENABLE_SIGNAL` | IO6 |
+| Temperature sensors (1-Wire, DS18B20) | `TEMP2_DQ` / `TEMP1_DQ` | IO7 / IO15 |
+| Shared SPI — MOSI, SCK, MISO | `MOSI` / `SCK` / `MISO` | IO11 / IO12 / IO13 |
+| MCP2515 #1 (Battery CAN) — CS, INT, RESET | `CS#1` / `INT#1` / `RESET1` | IO10 / IO21 / IO48 |
+| MCP2515 #2 (Drone CAN) — CS, INT, RESET | `CS#2` / `INT#2` / `RESET2` | IO14 / IO47 / IO9 |
 
 ## Functional Requirements
 
@@ -285,7 +272,7 @@ CBC_PCB/
 │   ├── connector-pinout.md ← connector/harness pinout and wiring notes
 │   ├── power-architecture.md ← power tree and protection notes
 │   └── schematic-review-followup.md ← schematic review action register
-├── firmware/               ← board-specific firmware (ESP32-C3)
+├── firmware/               ← board-specific firmware (ESP32-S3)
 ├── images/                 ← board renders, screenshots, diagrams, photos
 ├── kicad/                  ← KiCad 10 project files
 │   └── libs/               ← project-local KiCad libraries


### PR DESCRIPTION
## Summary

First pass of project documentation for the Docusaurus site, requested by Thomas in #caribou-docs.

- **`docs/index.md`** — project intro: mission, key capabilities, development status, repo structure, community links
- **`docs/architecture.md`** — system architecture: per-arm power design (no shared HV bus), propulsion, power/kill chain/isolation, avionics, structure, design lineage from Feather/Quiver
- **`docs/electronics/`** — overview + one page each for CBC, C90D, and CMAIN, sourced from the board READMEs and design docs
- The three placeholder PT1 docs (engineering report, structural assembly, maintenance guide) are marked `draft: true` so Docusaurus hides them from production builds until they have content
- Diagrams use plain ASCII (box-drawing characters misrender in the site code font)

## Sourcing notes

- Content is restricted to claims traceable to the repo, Hobbywing's published X15 specs (32.5–37.5 kg working / 72 kg max thrust per rotor), meeting notes, or the CBC firmware bench validation
- CBC pages reflect the as-ordered board (ESP32-S3-WROOM-1, per BOM/netlist) rather than the older ESP32-C3 references in the board README
- Known gaps for later (structure detail, avionics hardware, final harness pinout, kill-switch hardware, battery pack model, measured flight data) are listed in the Discord thread for a follow-up review issue for @far1no after build/flight test

## Test plan

- [ ] Docusaurus build succeeds with these files in `docs/`
- [ ] Intro page image (`docs/images/caribou_render.png`) renders
- [ ] Draft-marked PT1 pages are absent from the production build
- [ ] Cross-page links (intro ↔ architecture ↔ electronics) resolve
